### PR TITLE
Issue 57: Display message after fetching all finance records

### DIFF
--- a/Okane.Api/Okane.Api.csproj
+++ b/Okane.Api/Okane.Api.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.2"/>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2"/>
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.1"/>
-    <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.0.3"/>
+    <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
   </ItemGroup>
 

--- a/Okane.Client/src/__tests__/msw/handlers/financeRecord.ts
+++ b/Okane.Client/src/__tests__/msw/handlers/financeRecord.ts
@@ -37,9 +37,12 @@ export const FINANCE_RECORD_HANDLER_FACTORY = {
       return HttpResponse.json(createTestProblemDetails({ status }), { status })
     })
   },
-  GET_PAGINATED_FINANCE_RECORDS_SUCCESS(financeRecords: FinanceRecord[]) {
+  GET_PAGINATED_FINANCE_RECORDS_SUCCESS(financeRecords: FinanceRecord[], hasNextPage = true) {
     return http.get(`/api${FINANCE_RECORD_API_ROUTES.GET_PAGINATED_LIST.basePath}`, () => {
-      return HttpResponse.json(wrapInAPIPaginatedResponse(wrapInAPIResponse(financeRecords)))
+      return HttpResponse.json({
+        ...wrapInAPIPaginatedResponse(wrapInAPIResponse(financeRecords)),
+        hasNextPage,
+      })
     })
   },
   GET_PAGINATED_FINANCE_RECORDS_ERROR(detail?: string) {

--- a/Okane.Client/src/features/financeRecords/components/FinanceRecordList.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/FinanceRecordList.spec.ts
@@ -41,7 +41,7 @@ const mountComponent = getMountComponent(FinanceRecordList, {
 
 test('renders a list of finance records', async () => {
   testServer.use(
-    FINANCE_RECORD_HANDLER_FACTORY.GET_PAGINATED_FINANCE_RECORDS_SUCCESS(financeRecords),
+    FINANCE_RECORD_HANDLER_FACTORY.GET_PAGINATED_FINANCE_RECORDS_SUCCESS(financeRecords, false),
   )
 
   const wrapper = mountComponent()
@@ -55,6 +55,9 @@ test('renders a list of finance records', async () => {
 
   const noFinanceRecords = wrapper.findByText('p', FINANCES_COPY.INFINITE_LIST.NO_FINANCE_RECORDS)
   expect(noFinanceRecords).toBeUndefined()
+
+  const reachedTheBottom = wrapper.findByText('p', SHARED_COPY.INFINITE_SCROLLER.REACHED_THE_BOTTOM)
+  expect(reachedTheBottom).toBeDefined()
 })
 
 test('renders the expected message if no records exist', async () => {

--- a/Okane.Client/src/features/financeRecords/components/FinanceRecordList.vue
+++ b/Okane.Client/src/features/financeRecords/components/FinanceRecordList.vue
@@ -9,6 +9,7 @@ import InfiniteScroller from '@shared/components/InfiniteScroller.vue'
 
 import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 import { FINANCE_RECORD_SEARCH_FILTERS_KEY } from '@features/financeRecords/constants/searchFilters'
+import { SHARED_COPY } from '@shared/constants/copy'
 
 import { useInfiniteQueryFinanceRecords } from '@features/financeRecords/composables/useInfiniteQueryFinanceRecords'
 
@@ -37,6 +38,10 @@ function handleStartDelete(id: number) {
       <template #noItems>
         <p>{{ FINANCES_COPY.INFINITE_LIST.NO_FINANCE_RECORDS }}</p>
       </template>
+
+      <template #noMoreItems>
+        <p class="no-more-items">{{ SHARED_COPY.INFINITE_SCROLLER.REACHED_THE_BOTTOM }}</p>
+      </template>
     </InfiniteScroller>
   </div>
 
@@ -55,5 +60,11 @@ function handleStartDelete(id: number) {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+}
+
+.no-more-items {
+  color: var(--color-gray-300);
+  margin-block: var(--space-xl);
+  text-align: center;
 }
 </style>

--- a/Okane.Client/src/shared/components/InfiniteScroller.spec.ts
+++ b/Okane.Client/src/shared/components/InfiniteScroller.spec.ts
@@ -29,6 +29,7 @@ const testIds = {
   loader: 'loader',
   loadMoreButton: 'loadMoreButton',
   noItemsSlot: 'noItemsSlot',
+  noMoreItemsSlot: 'noMoreItemsSlot',
 }
 
 function getTestComponent(errorTemplate?: string) {
@@ -55,6 +56,10 @@ function getTestComponent(errorTemplate?: string) {
         </template>
         
         ${errorTemplate && `<template #error>${errorTemplate}</template>`}
+        
+        <template #noMoreItems>
+          <div data-testid="${testIds.noMoreItemsSlot}" />
+        </template>
       </InfiniteScroller>
     `,
   })
@@ -113,6 +118,32 @@ test('renders the default slot when the response contains items', async () => {
   expect(defaultSlot.exists()).toBe(true)
 })
 
+describe('when there is no next page', () => {
+  beforeEach(() => {
+    testServer.use(
+      FINANCE_RECORD_HANDLER_FACTORY.GET_PAGINATED_FINANCE_RECORDS_SUCCESS(financeRecords, false),
+    )
+  })
+
+  test('renders the noMoreItems slot', async () => {
+    const wrapper = mountComponent()
+
+    await flushPromises()
+
+    const noMoreItemsSlot = wrapper.find(`[data-testid="${testIds.noMoreItemsSlot}"]`)
+    expect(noMoreItemsSlot.exists()).toBe(true)
+  })
+
+  test('does not render the noItems slot', async () => {
+    const wrapper = mountComponent()
+
+    await flushPromises()
+
+    const noItemsSlot = wrapper.find(`[data-testid="${testIds.noItemsSlot}"]`)
+    expect(noItemsSlot.exists()).toBe(false)
+  })
+})
+
 describe('when the response contains no items', () => {
   beforeEach(() => {
     testServer.use(FINANCE_RECORD_HANDLER_FACTORY.GET_PAGINATED_FINANCE_RECORDS_SUCCESS([]))
@@ -134,6 +165,15 @@ describe('when the response contains no items', () => {
 
     const defaultSlot = wrapper.find(`[data-testid="${testIds.defaultSlot}"]`)
     expect(defaultSlot.exists()).toBe(false)
+  })
+
+  test('does not render noMoreItems slot', async () => {
+    const wrapper = mountComponent()
+
+    await flushPromises()
+
+    const noMoreItems = wrapper.find(`[data-testid="${testIds.noMoreItemsSlot}"]`)
+    expect(noMoreItems.exists()).toBe(false)
   })
 })
 

--- a/Okane.Client/src/shared/components/InfiniteScroller.vue
+++ b/Okane.Client/src/shared/components/InfiniteScroller.vue
@@ -38,6 +38,11 @@ function handleObserverChange(isIntersecting: boolean) {
       <Observer :watch-dep="props.queryResult.data" @change="handleObserverChange" />
     </div>
 
+    <slot
+      v-if="props.items.length > 0 && !props.queryResult.hasNextPage.value"
+      name="noMoreItems"
+    />
+
     <div v-if="showLoader" class="loader">
       <Loader />
     </div>

--- a/Okane.Client/src/shared/constants/copy.ts
+++ b/Okane.Client/src/shared/constants/copy.ts
@@ -5,6 +5,9 @@ export const SHARED_COPY = {
     EDIT: 'Edit',
     SAVE: 'Save',
   },
+  INFINITE_SCROLLER: {
+    REACHED_THE_BOTTOM: "You've reached the bottom.",
+  },
   MENU: {
     TOGGLE_MENU: 'Toggle Menu',
   },


### PR DESCRIPTION
## Description
- `InfiniteScroller` Add slot that's rendered when all items have been fetched
- API: Fix Serilog dep error: `warning NU1902: Package 'Serilog.Enrichers.ClientInfo' 2.0.3 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-5x5q-cqf6-gj8r`


## Linked issues
#57