### PR TITLE
66-FE: Update API routes to be record of functions

### DIFF
--- a/Okane.Client/src/__tests__/msw/handlers/auth.ts
+++ b/Okane.Client/src/__tests__/msw/handlers/auth.ts
@@ -7,7 +7,7 @@ import { HTTP_STATUS_CODE } from '@shared/constants/http'
 
 export const authHandlers = {
   logoutSuccess() {
-    return http.post(`/api${authAPIRoutes.logout.buildPath()}`, () => {
+    return http.post(`/api${authAPIRoutes.logout()}`, () => {
       return new HttpResponse(null, { status: HTTP_STATUS_CODE.NO_CONTENT_204 })
     })
   },

--- a/Okane.Client/src/__tests__/msw/handlers/financeRecord.ts
+++ b/Okane.Client/src/__tests__/msw/handlers/financeRecord.ts
@@ -8,26 +8,23 @@ import { HTTP_STATUS_CODE } from '@shared/constants/http'
 import type { FinanceRecord } from '@features/financeRecords/types/financeRecord'
 
 import { createTestProblemDetails } from '@tests/factories/problemDetails'
+import { getMSWURL } from '@tests/utils/url'
 import { wrapInAPIPaginatedResponse, wrapInAPIResponse } from '@tests/utils/apiResponse'
 
 export const financeRecordHandlers = {
   deleteFinanceRecordSuccess({ id }: { id: number }) {
-    return http.delete(
-      `/api${financeRecordAPIRoutes.deleteFinanceRecord.buildPath({ id })}`,
-      () => {
-        return new HttpResponse(null, { status: HTTP_STATUS_CODE.NO_CONTENT_204 })
-      },
-    )
+    const url = getMSWURL(financeRecordAPIRoutes.deleteFinanceRecord({ id }))
+    return http.delete(url, () => {
+      return new HttpResponse(null, { status: HTTP_STATUS_CODE.NO_CONTENT_204 })
+    })
   },
   deleteFinanceRecordError({ id }: { id: number }) {
+    const url = getMSWURL(financeRecordAPIRoutes.deleteFinanceRecord({ id }))
     const status = HTTP_STATUS_CODE.BAD_REQUEST_400
 
-    return http.delete(
-      `/api${financeRecordAPIRoutes.deleteFinanceRecord.buildPath({ id })}`,
-      () => {
-        return HttpResponse.json(createTestProblemDetails({ status }), { status })
-      },
-    )
+    return http.delete(url, () => {
+      return HttpResponse.json(createTestProblemDetails({ status }), { status })
+    })
   },
   getPaginatedFinanceRecordsSuccess({
     financeRecords,
@@ -36,7 +33,8 @@ export const financeRecordHandlers = {
     financeRecords: FinanceRecord[]
     hasNextPage?: boolean
   }) {
-    return http.get(`/api${financeRecordAPIRoutes.getPaginatedList.basePath}`, () => {
+    const url = getMSWURL(financeRecordAPIRoutes.getPaginatedList({ page: 0 }))
+    return http.get(url, () => {
       return HttpResponse.json({
         ...wrapInAPIPaginatedResponse(wrapInAPIResponse(financeRecords)),
         hasNextPage,
@@ -44,7 +42,8 @@ export const financeRecordHandlers = {
     })
   },
   getPaginatedFinanceRecordsError({ detail }: { detail?: string }) {
-    return http.get(`/api${financeRecordAPIRoutes.getPaginatedList.basePath}`, () => {
+    const url = getMSWURL(financeRecordAPIRoutes.getPaginatedList({ page: 0 }))
+    return http.get(url, () => {
       return HttpResponse.json(createTestProblemDetails({ detail }), {
         status: HTTP_STATUS_CODE.BAD_REQUEST_400,
       })

--- a/Okane.Client/src/__tests__/utils/url.ts
+++ b/Okane.Client/src/__tests__/utils/url.ts
@@ -1,0 +1,6 @@
+// Internal
+import { stripSearchParams } from '@shared/utils/url'
+
+export function getMSWURL(url: string) {
+  return stripSearchParams(`/api${url}`)
+}

--- a/Okane.Client/src/features/auth/composables/useAuthStore.spec.ts
+++ b/Okane.Client/src/features/auth/composables/useAuthStore.spec.ts
@@ -28,13 +28,9 @@ const authResponse: AuthenticateResponse = {
 
 beforeEach(() => {
   testServer.use(
-    http.post(`/api${authAPIRoutes.login.buildPath()}`, () => HttpResponse.json(authResponse)),
-    http.post(`/api${authAPIRoutes.refreshToken.buildPath()}`, () =>
-      HttpResponse.json(authResponse),
-    ),
-    http.post(`/api${authAPIRoutes.logout.buildPath()}`, () =>
-      HttpResponse.json(wrapInAPIResponse(null)),
-    ),
+    http.post(`/api${authAPIRoutes.login()}`, () => HttpResponse.json(authResponse)),
+    http.post(`/api${authAPIRoutes.refreshToken()}`, () => HttpResponse.json(authResponse)),
+    http.post(`/api${authAPIRoutes.logout()}`, () => HttpResponse.json(wrapInAPIResponse(null))),
   )
 })
 
@@ -50,7 +46,7 @@ test('register', async () => {
 
   expect(spy).toHaveBeenCalledTimes(1)
   expect(spy).toHaveBeenCalledWith(
-    authAPIRoutes.register.buildPath(),
+    authAPIRoutes.register(),
     omitObjectKeys(formData, ['passwordConfirm']),
   )
 })

--- a/Okane.Client/src/features/auth/composables/useAuthStore.ts
+++ b/Okane.Client/src/features/auth/composables/useAuthStore.ts
@@ -31,7 +31,7 @@ export const useAuthStore = defineStore('AuthStore', () => {
    * @param password
    */
   async function register(email: string, name: string, password: string): Promise<void> {
-    await apiClient.post(authAPIRoutes.register.buildPath(), { email, name, password })
+    await apiClient.post(authAPIRoutes.register(), { email, name, password })
   }
 
   /**
@@ -49,9 +49,7 @@ export const useAuthStore = defineStore('AuthStore', () => {
    * Get a new JWT token and update the auth store.
    */
   async function handleRefreshToken() {
-    const response = await apiClient.post<AuthenticateResponse>(
-      authAPIRoutes.refreshToken.buildPath(),
-    )
+    const response = await apiClient.post<AuthenticateResponse>(authAPIRoutes.refreshToken())
     initState(response)
   }
 
@@ -89,7 +87,7 @@ export const useAuthStore = defineStore('AuthStore', () => {
    * Log out the user by clearing the store state.
    */
   async function logout() {
-    await apiClient.post(authAPIRoutes.logout.buildPath())
+    await apiClient.post(authAPIRoutes.logout())
     clearTimeout(refreshTokenInterval.value)
 
     authUser.value = undefined

--- a/Okane.Client/src/features/auth/constants/apiRoutes.ts
+++ b/Okane.Client/src/features/auth/constants/apiRoutes.ts
@@ -1,28 +1,9 @@
+// Internal
 const basePath = '/auth'
 
 export const authAPIRoutes = {
-  login: {
-    basePath,
-    buildPath() {
-      return `${basePath}/login`
-    },
-  },
-  logout: {
-    basePath,
-    buildPath() {
-      return `${basePath}/logout`
-    },
-  },
-  refreshToken: {
-    basePath,
-    buildPath() {
-      return `${basePath}/refresh-token`
-    },
-  },
-  register: {
-    basePath,
-    buildPath() {
-      return `${basePath}/register`
-    },
-  },
+  login: () => `${basePath}/login`,
+  logout: () => `${basePath}/logout`,
+  refreshToken: () => `${basePath}/refresh-token`,
+  register: () => `${basePath}/register`,
 } as const

--- a/Okane.Client/src/features/financeRecords/components/CreateFinanceRecordModal.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/CreateFinanceRecordModal.spec.ts
@@ -86,10 +86,7 @@ describe('with a successful request to create a finance record', () => {
 
     const financeRecord = mapSaveFinanceRecordFormState.to.preCreationFinanceRecord(formState)
     expect(postSpy).toHaveBeenCalledOnce()
-    expect(postSpy).toHaveBeenCalledWith(
-      financeRecordAPIRoutes.postFinanceRecord.buildPath(),
-      financeRecord,
-    )
+    expect(postSpy).toHaveBeenCalledWith(financeRecordAPIRoutes.postFinanceRecord(), financeRecord)
 
     postSpy.mockRestore()
   })

--- a/Okane.Client/src/features/financeRecords/components/EditFinanceRecordModal.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/EditFinanceRecordModal.spec.ts
@@ -129,7 +129,7 @@ describe('with a successful request to edit a finance record', () => {
     const financeRecord = mapSaveFinanceRecordFormState.to.partialFinanceRecord(updates)
     expect(patchSpy).toHaveBeenCalledOnce()
     expect(patchSpy).toHaveBeenCalledWith(
-      financeRecordAPIRoutes.patchFinanceRecord.buildPath({ id: editingFinanceRecord.id }),
+      financeRecordAPIRoutes.patchFinanceRecord({ id: editingFinanceRecord.id }),
       financeRecord,
     )
 

--- a/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.spec.ts
@@ -48,10 +48,7 @@ test('makes a POST request to the expected endpoint', async () => {
 
   await flushPromises()
 
-  expect(postSpy).toHaveBeenCalledWith(
-    financeRecordAPIRoutes.postFinanceRecord.buildPath(),
-    financeRecord,
-  )
+  expect(postSpy).toHaveBeenCalledWith(financeRecordAPIRoutes.postFinanceRecord(), financeRecord)
 })
 
 test('invalidates the query key when search filters are passed', async () => {

--- a/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.ts
@@ -10,7 +10,7 @@ import { type PreCreationFinanceRecord } from '@features/financeRecords/types/sa
 import { apiClient } from '@shared/services/apiClient/apiClient'
 
 function postFinanceRecord(financeRecord: PreCreationFinanceRecord) {
-  return apiClient.post(financeRecordAPIRoutes.postFinanceRecord.buildPath(), financeRecord)
+  return apiClient.post(financeRecordAPIRoutes.postFinanceRecord(), financeRecord)
 }
 
 export function useCreateFinanceRecordMutation(queryKey: MaybeRefOrGetter<QueryKey>) {

--- a/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.spec.ts
@@ -47,7 +47,7 @@ test('makes a DELETE request to the expected endpoint', async () => {
   await flushPromises()
 
   expect(deleteSpy).toHaveBeenCalledWith(
-    financeRecordAPIRoutes.deleteFinanceRecord.buildPath({ id: financeRecordId }),
+    financeRecordAPIRoutes.deleteFinanceRecord({ id: financeRecordId }),
   )
 })
 

--- a/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.ts
@@ -13,7 +13,7 @@ import type { FinanceRecord } from '@features/financeRecords/types/financeRecord
 import { removeItemFromPages } from '@shared/utils/pagination'
 
 function deleteFinanceRecord(id: number) {
-  return apiClient.delete(financeRecordAPIRoutes.deleteFinanceRecord.buildPath({ id }))
+  return apiClient.delete(financeRecordAPIRoutes.deleteFinanceRecord({ id }))
 }
 
 export function useDeleteFinanceRecordMutation(queryKey: MaybeRefOrGetter<QueryKey>) {

--- a/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.spec.ts
@@ -48,10 +48,7 @@ test('makes a PATCH request to the expected endpoint', async () => {
 
   mountComponent()
   await flushPromises()
-  expect(patchSpy).toHaveBeenCalledWith(
-    financeRecordAPIRoutes.patchFinanceRecord.buildPath({ id }),
-    changes,
-  )
+  expect(patchSpy).toHaveBeenCalledWith(financeRecordAPIRoutes.patchFinanceRecord({ id }), changes)
 
   patchSpy.mockRestore()
 })

--- a/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.ts
@@ -10,7 +10,7 @@ import { type FinanceRecord } from '@features/financeRecords/types/financeRecord
 import { apiClient } from '@shared/services/apiClient/apiClient'
 
 function patchFinanceRecord(id: number, changes: Partial<FinanceRecord>) {
-  return apiClient.patch(financeRecordAPIRoutes.patchFinanceRecord.buildPath({ id }), changes)
+  return apiClient.patch(financeRecordAPIRoutes.patchFinanceRecord({ id }), changes)
 }
 
 type MutationArgs = {

--- a/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.spec.ts
@@ -35,7 +35,7 @@ test('makes a request to fetch paginated finance records', () => {
   mountComponent()
 
   expect(getSpy).toHaveBeenCalledWith(
-    financeRecordAPIRoutes.getPaginatedList.buildPath({ page: INITIAL_PAGE }),
+    financeRecordAPIRoutes.getPaginatedList({ page: INITIAL_PAGE }),
     {
       signal: new AbortController().signal,
     },

--- a/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.ts
@@ -20,7 +20,7 @@ export function fetchPaginatedFinanceRecords({
   pageParam,
   signal,
 }: QueryFunctionContext): Promise<APIPaginatedResponse<FinanceRecord>> {
-  return apiClient.get(financeRecordAPIRoutes.getPaginatedList.buildPath({ page: pageParam }), {
+  return apiClient.get(financeRecordAPIRoutes.getPaginatedList({ page: pageParam }), {
     signal,
   })
 }

--- a/Okane.Client/src/features/financeRecords/constants/apiRoutes.ts
+++ b/Okane.Client/src/features/financeRecords/constants/apiRoutes.ts
@@ -3,30 +3,11 @@ import { DEFAULT_PAGE_SIZE, INITIAL_PAGE } from '@shared/constants/request'
 
 const basePath = '/finance-records'
 
-// TODO: Update basePath to also be a function...
 export const financeRecordAPIRoutes = {
-  getPaginatedList: {
-    basePath,
-    buildPath({ page = INITIAL_PAGE }: { page: unknown }) {
-      return `${basePath}?page=${page}&pageSize=${DEFAULT_PAGE_SIZE}`
-    },
+  getPaginatedList({ page = INITIAL_PAGE }: { page: unknown }) {
+    return `${basePath}?page=${page}&pageSize=${DEFAULT_PAGE_SIZE}`
   },
-  deleteFinanceRecord: {
-    basePath,
-    buildPath({ id }: { id: number }) {
-      return `${basePath}/${id}`
-    },
-  },
-  patchFinanceRecord: {
-    basePath,
-    buildPath({ id }: { id: number }) {
-      return `${basePath}/${id}`
-    },
-  },
-  postFinanceRecord: {
-    basePath,
-    buildPath() {
-      return basePath
-    },
-  },
+  deleteFinanceRecord: ({ id }: { id: number }) => `${basePath}/${id}`,
+  patchFinanceRecord: ({ id }: { id: number }) => `${basePath}/${id}`,
+  postFinanceRecord: () => basePath,
 } as const

--- a/Okane.Client/src/shared/components/InfiniteScroller.spec.ts
+++ b/Okane.Client/src/shared/components/InfiniteScroller.spec.ts
@@ -19,6 +19,7 @@ import { getRange } from '@shared/utils/array'
 import { wrapInAPIPaginatedResponse, wrapInAPIResponse } from '@tests/utils/apiResponse'
 
 import { createTestFinanceRecord } from '@tests/factories/financeRecord'
+import { getMSWURL } from '@tests/utils/url'
 import { setUpIntersectionObserverMock } from '@tests/mocks/intersectionObserver'
 import { testServer } from '@tests/msw/testServer'
 import { withSearchParams } from '@tests/msw/resolvers/withSearchParams'
@@ -211,7 +212,7 @@ describe(`when there are more pages to fetch page`, () => {
   const page3FinanceRecord = createTestFinanceRecord({ description: 'page3FinanceRecord' })
 
   beforeEach(() => {
-    const apiRoute = `/api${financeRecordAPIRoutes.getPaginatedList.basePath}`
+    const apiRoute = getMSWURL(financeRecordAPIRoutes.getPaginatedList({ page: 0 }))
 
     testServer.use(
       http.get(

--- a/Okane.Client/src/shared/services/apiClient/apiClient.spec.ts
+++ b/Okane.Client/src/shared/services/apiClient/apiClient.spec.ts
@@ -143,9 +143,7 @@ describe('when logged in', () => {
     expect(response.items[0]).toEqual('pong')
   })
 
-  const logoutHandler = http.post(`/api${authAPIRoutes.logout.buildPath()}`, () =>
-    HttpResponse.json(),
-  )
+  const logoutHandler = http.post(`/api${authAPIRoutes.logout()}`, () => HttpResponse.json())
   const getErrorHandler = (statusCode: HTTP_STATUS_CODE) =>
     http.get('/api/ping', () => {
       const errorResponse = JSON.stringify(createTestProblemDetails())

--- a/Okane.Client/src/shared/utils/url.spec.ts
+++ b/Okane.Client/src/shared/utils/url.spec.ts
@@ -1,0 +1,14 @@
+// Internal
+import * as utils from '@shared/utils/url'
+
+describe('stripSearchParams', () => {
+  test.each([
+    { input: '', expected: '' },
+    { input: ' ', expected: ' ' },
+    { input: 'google.com', expected: 'google.com' },
+    { input: 'google.com?a=1&b=2', expected: 'google.com' },
+    { input: 'google.com?a=1?b=2', expected: 'google.com' },
+  ])('stripSearchParams("$input") -> $expected', ({ input, expected }) => {
+    expect(utils.stripSearchParams(input)).toBe(expected)
+  })
+})

--- a/Okane.Client/src/shared/utils/url.ts
+++ b/Okane.Client/src/shared/utils/url.ts
@@ -1,0 +1,5 @@
+export function stripSearchParams(url: string) {
+  const questionIndex = url.indexOf('?')
+  if (questionIndex === -1) return url
+  return url.slice(0, questionIndex)
+}


### PR DESCRIPTION
## Description
- replace `basePath` and `buildPath` from API route constants with a single function
- add a util func to generate paths for MSW handlers


## Linked issues
#66