### PR TITLE
Issue 73: Create endpoint for finance records stats

### DIFF
--- a/Okane.Api.Tests/Features/FinanceRecords/Endpoints/GetFinanceRecordsStatsTests.cs
+++ b/Okane.Api.Tests/Features/FinanceRecords/Endpoints/GetFinanceRecordsStatsTests.cs
@@ -1,0 +1,119 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Okane.Api.Features.Finances.Dtos;
+using Okane.Api.Features.Finances.Entities;
+using Okane.Api.Shared.Dtos.ApiResponses;
+using Okane.Api.Tests.Testing.Integration;
+using Okane.Api.Tests.Testing.StubFactories;
+using Okane.Api.Tests.Testing.Utils;
+
+namespace Okane.Api.Tests.Features.FinanceRecords.Endpoints;
+
+public class GetFinanceRecordsStatsTests(PostgresApiFactory apiFactory) : DatabaseTest(apiFactory)
+{
+    private readonly HttpClient _client = apiFactory.CreateClient();
+    private static readonly FinanceRecordsStats s_emptyStats = new();
+
+    private static FinanceRecord CreateRecordWithAmountAndType(
+        decimal amount,
+        FinanceRecordType type,
+        string userId)
+    {
+        var record = FinanceRecordStubFactory.Create(userId);
+        record.Amount = amount;
+        record.Type = type;
+
+        return record;
+    }
+
+    [Fact]
+    public async Task ReturnsStats_MatchingTheSearchFilters()
+    {
+        var loginResponse = await _client.RegisterAndLogInTestUserAsync();
+        var userId = loginResponse.User.Id;
+
+        var revenue1 = CreateRecordWithAmountAndType(5.40m, FinanceRecordType.Revenue, userId);
+        var revenue2 = CreateRecordWithAmountAndType(7.20m, FinanceRecordType.Revenue, userId);
+        var expense1 = CreateRecordWithAmountAndType(3.60m, FinanceRecordType.Expense, userId);
+        var expense2 = CreateRecordWithAmountAndType(3.60m, FinanceRecordType.Expense, userId);
+        await Db.AddRangeAsync([revenue1, expense1, revenue2, expense2]);
+        await Db.SaveChangesAsync();
+
+        var expenseResponse = await _client.GetAsync("/finance-records/stats?Type=Expense");
+        expenseResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+        var expenseApiResponse = await expenseResponse
+            .Content
+            .ReadFromJsonAsync<ApiResponse<FinanceRecordsStats>>();
+        expenseApiResponse?.Items[0].Should().BeEquivalentTo(s_emptyStats with
+        {
+            TotalExpenses = expense1.Amount + expense2.Amount,
+            ExpenseRecords = 2
+        });
+
+        var allResponse = await _client.GetAsync("/finance-records/stats");
+        allResponse.Should().HaveStatusCode(HttpStatusCode.OK);
+
+        var allApiResponse = await allResponse
+            .Content
+            .ReadFromJsonAsync<ApiResponse<FinanceRecordsStats>>();
+        allApiResponse?.Items[0].Should().BeEquivalentTo(new FinanceRecordsStats
+        {
+            TotalExpenses = expense1.Amount + expense2.Amount,
+            ExpenseRecords = 2,
+            TotalRevenue = revenue1.Amount + revenue2.Amount,
+            RevenueRecords = 2
+        });
+    }
+
+    [Fact]
+    public async Task ReturnsEmptyStats_WithNoMatchingFinanceRecords()
+    {
+        var loginResponse = await _client.RegisterAndLogInTestUserAsync();
+        var response = await _client.GetAsync("/finance-records/stats");
+        response.Should().HaveStatusCode(HttpStatusCode.OK);
+
+        var apiResponse = await response
+            .Content
+            .ReadFromJsonAsync<ApiResponse<FinanceRecordsStats>>();
+        apiResponse?.Items[0].Should().BeEquivalentTo(s_emptyStats);
+
+        var revenueRecord = FinanceRecordStubFactory.Create(loginResponse.User.Id);
+        revenueRecord.Type = FinanceRecordType.Revenue;
+        await Db.AddAsync(revenueRecord);
+        await Db.SaveChangesAsync();
+
+        response = await _client.GetAsync("/finance-records/stats?type=Expense");
+        response.Should().HaveStatusCode(HttpStatusCode.OK);
+
+        apiResponse = await response.Content.ReadFromJsonAsync<ApiResponse<FinanceRecordsStats>>();
+        apiResponse?.Items[0].Should().BeEquivalentTo(s_emptyStats);
+    }
+
+    [Fact]
+    public async Task ExcludesRecordsCreatedByOtherUsers()
+    {
+        var otherUser = await UserUtils.RegisterUserAsync(_client);
+        var otherRecord = CreateRecordWithAmountAndType(1, FinanceRecordType.Revenue, otherUser.Id);
+
+        var loginResponse = await _client.RegisterAndLogInTestUserAsync();
+        var ownRecord = CreateRecordWithAmountAndType(2, FinanceRecordType.Expense, loginResponse.User.Id);
+
+        await Db.AddRangeAsync(otherRecord, ownRecord);
+        await Db.SaveChangesAsync();
+
+        var response = await _client.GetAsync("/finance-records/stats");
+        response.Should().HaveStatusCode(HttpStatusCode.OK);
+
+        var apiResponse = await response
+            .Content
+            .ReadFromJsonAsync<ApiResponse<FinanceRecordsStats>>();
+
+        apiResponse?.Items[0].Should().BeEquivalentTo(new FinanceRecordsStats
+        {
+            ExpenseRecords = 1,
+            TotalExpenses = ownRecord.Amount
+        });
+    }
+}

--- a/Okane.Api/Features/Finances/Constants/FinanceRecordEndpointNames.cs
+++ b/Okane.Api/Features/Finances/Constants/FinanceRecordEndpointNames.cs
@@ -3,6 +3,7 @@ namespace Okane.Api.Features.Finances.Constants;
 public static class FinanceRecordEndpointNames
 {
     public const string GetFinanceRecord = "GetFinanceRecord";
+    public const string GetFinanceRecordsStats = "GetFinanceRecordsStats";
     public const string GetPaginatedFinanceRecords = "GetPaginatedFinanceRecords";
     public const string PostFinanceRecord = "PostFinanceRecord";
     public const string PatchFinanceRecord = "PatchFinanceRecord";

--- a/Okane.Api/Features/Finances/Dtos/FinanceRecordsStats.cs
+++ b/Okane.Api/Features/Finances/Dtos/FinanceRecordsStats.cs
@@ -1,0 +1,9 @@
+namespace Okane.Api.Features.Finances.Dtos;
+
+public record FinanceRecordsStats
+{
+    public int ExpenseRecords { get; set; }
+    public int RevenueRecords { get; set; }
+    public decimal TotalExpenses { get; set; }
+    public decimal TotalRevenue { get; set; }
+}

--- a/Okane.Api/Features/Finances/Endpoints/GetFinanceRecordsStats.cs
+++ b/Okane.Api/Features/Finances/Endpoints/GetFinanceRecordsStats.cs
@@ -1,0 +1,65 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using Okane.Api.Features.Auth.Extensions;
+using Okane.Api.Features.Finances.Constants;
+using Okane.Api.Features.Finances.Dtos;
+using Okane.Api.Features.Finances.Entities;
+using Okane.Api.Features.Finances.Services;
+using Okane.Api.Infrastructure.Database;
+using Okane.Api.Infrastructure.Endpoints;
+using Okane.Api.Shared.Dtos.ApiResponses;
+
+namespace Okane.Api.Features.Finances.Endpoints;
+
+public class GetFinanceRecordsStats : IEndpoint
+{
+    public static void Map(IEndpointRouteBuilder builder)
+    {
+        builder
+            .MapGet("/stats", HandleAsync)
+            .WithName(FinanceRecordEndpointNames.GetFinanceRecordsStats)
+            .WithSummary("Get stats for finance records matching the given search criteria.");
+    }
+
+    private record StatsByType(FinanceRecordType Type, int Count, decimal Sum);
+
+    private static async Task<Ok<ApiResponse<FinanceRecordsStats>>> HandleAsync(
+        ClaimsPrincipal claimsPrincipal,
+        HttpContext context,
+        ApiDbContext db,
+        IFinanceRecordService financeRecordService,
+        [AsParameters] FinanceRecordFilterQueryParameters filterParameters,
+        CancellationToken cancellationToken)
+    {
+        var userId = claimsPrincipal.GetUserId();
+        var query = financeRecordService.FilterQueryableFinanceRecords(
+            db.FinanceRecords.AsNoTracking(),
+            filterParameters,
+            userId
+        );
+
+        var stats = new FinanceRecordsStats();
+        var statsByTypes = await query.GroupBy(fr => fr.Type).Select(g => new StatsByType(
+            g.Key,
+            g.Count(),
+            g.Sum(fr => fr.Amount)
+        )).ToListAsync(cancellationToken);
+
+        foreach (var statsByType in statsByTypes)
+        {
+            if (statsByType.Type == FinanceRecordType.Revenue)
+            {
+                stats.RevenueRecords = statsByType.Count;
+                stats.TotalRevenue = statsByType.Sum;
+            }
+            else
+            {
+                stats.ExpenseRecords = statsByType.Count;
+                stats.TotalExpenses = statsByType.Sum;
+            }
+        }
+
+        return TypedResults.Ok(new ApiResponse<FinanceRecordsStats>(stats));
+    }
+}

--- a/Okane.Api/Features/Finances/Services/FinanceRecordService.cs
+++ b/Okane.Api/Features/Finances/Services/FinanceRecordService.cs
@@ -42,6 +42,7 @@ public class FinanceRecordService : IFinanceRecordService
 
         if (parameters.Description is not null)
         {
+            // TODO(70) Use tsvector.
             query = query.Where(
                 r => EF.Functions.ILike(r.Description, $"%{parameters.Description}%")
             );

--- a/Okane.Api/Infrastructure/Endpoints/Endpoints.cs
+++ b/Okane.Api/Infrastructure/Endpoints/Endpoints.cs
@@ -31,6 +31,7 @@ public static class Endpoints
             .WithTags("Finance Records")
             .MapEndpoint<GetFinanceRecord>()
             .MapEndpoint<GetPaginatedFinanceRecords>()
+            .MapEndpoint<GetFinanceRecordsStats>()
             .MapEndpoint<PostFinanceRecord>()
             .MapEndpoint<PatchFinanceRecord>()
             .MapEndpoint<DeleteFinanceRecord>();

--- a/Requests/finance-records/stats/getStats
+++ b/Requests/finance-records/stats/getStats
@@ -1,0 +1,4 @@
+GET {{BASE_URL}}/finance-records/stats
+Authorization: {{AUTH_HEADER}}
+
+HTTP 200


### PR DESCRIPTION
## Description
Add endpoint for finance records stats: `/api/finance-records/stats`. The endpoint takes almost the same query parameters as the regular GET paginated endpoint (excluding sort & page params).



## Linked issues
#73