### PR TITLE
Issue 73: Display stats for finance records

### DIFF
--- a/Okane.Client/src/features/financeRecords/components/CreateFinanceRecordModal.vue
+++ b/Okane.Client/src/features/financeRecords/components/CreateFinanceRecordModal.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 // External
-import { computed, inject, ref } from 'vue'
+import { inject, ref } from 'vue'
 
 // Internal
 import SaveFinanceRecordModal from '@features/financeRecords/components/SaveFinanceRecordModal.vue'
 
 import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
-import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
 
 import type { SaveFinanceRecordFormState } from '@features/financeRecords/types/saveFinanceRecord'
 
@@ -17,22 +16,14 @@ import {
   type SaveFinanceRecordProvider,
 } from '@features/financeRecords/providers/saveFinanceRecordProvider'
 
-import {
-  SEARCH_FINANCE_RECORDS_SYMBOL,
-  type SearchFinanceRecordsProvider,
-} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
-
 import { getFormErrorsFromAPIResponse } from '@shared/services/apiClient/utils'
 import { getInitialFormErrors } from '@shared/utils/form'
 import { getInitialSaveFinanceRecordFormState } from '@features/financeRecords/utils/saveFinanceRecord'
 import { isObjectType } from '@shared/utils/object'
 import { mapSaveFinanceRecordFormState } from '@features/financeRecords/utils/mappers'
 
+const createMutation = useCreateFinanceRecordMutation()
 const saveProvider = inject(SAVE_FINANCE_RECORD_SYMBOL) as SaveFinanceRecordProvider
-const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
-
-const queryKey = computed(() => financeRecordQueryKeys.listByFilters(searchProvider.filters))
-const createMutation = useCreateFinanceRecordMutation(queryKey)
 
 const formState = ref<SaveFinanceRecordFormState>(getInitialSaveFinanceRecordFormState())
 const initialFormErrors = getInitialFormErrors(formState.value)

--- a/Okane.Client/src/features/financeRecords/components/DeleteFinanceRecordModal.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/DeleteFinanceRecordModal.spec.ts
@@ -118,15 +118,11 @@ describe('when clicking the delete button', () => {
     return { deleteProvider, wrapper }
   }
 
-  test('calls useDeleteFinanceRecordMutation with the query key', async () => {
+  test('calls useDeleteFinanceRecordMutation', async () => {
     const deleteSpy = vi.spyOn(deleteMutation, 'useDeleteFinanceRecordMutation')
     await setUp()
 
     expect(deleteSpy).toHaveBeenCalledOnce()
-
-    const calledWith = deleteSpy.mock.calls[0]
-    const [queryKey] = calledWith
-    expect(toValue(queryKey)).toEqual(financeRecordQueryKeys.listByFilters(searchFilters))
 
     deleteSpy.mockRestore()
   })

--- a/Okane.Client/src/features/financeRecords/components/DeleteFinanceRecordModal.vue
+++ b/Okane.Client/src/features/financeRecords/components/DeleteFinanceRecordModal.vue
@@ -1,21 +1,15 @@
 <script setup lang="ts">
 // External
-import { computed, inject } from 'vue'
+import { inject } from 'vue'
 
 // Internal
 import DeleteFinanceRecordModalActions from '@features/financeRecords/components/DeleteFinanceRecordModalActions.vue'
 import Modal from '@shared/components/modal/Modal.vue'
 import ModalHeading from '@shared/components/modal/ModalHeading.vue'
 
-import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
 import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 
 import { useDeleteFinanceRecordMutation } from '@features/financeRecords/composables/useDeleteFinanceRecordMutation'
-
-import {
-  SEARCH_FINANCE_RECORDS_SYMBOL,
-  type SearchFinanceRecordsProvider,
-} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
 
 import {
   DELETE_FINANCE_RECORD_ID_SYMBOL,
@@ -23,11 +17,9 @@ import {
 } from '@features/financeRecords/providers/deleteFinanceRecordIdProvider'
 
 const deleteProvider = inject(DELETE_FINANCE_RECORD_ID_SYMBOL) as DeleteFinanceRecordIdProvider
-const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
 
 const modalHeadingId = 'delete-finance-record-modal-heading'
-const queryKey = computed(() => financeRecordQueryKeys.listByFilters(searchProvider.filters))
-const deleteMutation = useDeleteFinanceRecordMutation(queryKey)
+const deleteMutation = useDeleteFinanceRecordMutation()
 
 function handleClose() {
   deleteProvider.setId(undefined)

--- a/Okane.Client/src/features/financeRecords/components/EditFinanceRecordModal.vue
+++ b/Okane.Client/src/features/financeRecords/components/EditFinanceRecordModal.vue
@@ -5,7 +5,6 @@ import { computed, inject, ref, watchEffect } from 'vue'
 // Internal
 import SaveFinanceRecordModal from '@features/financeRecords/components/SaveFinanceRecordModal.vue'
 
-import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
 import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 
 import type { SaveFinanceRecordFormState } from '@features/financeRecords/types/saveFinanceRecord'
@@ -16,10 +15,6 @@ import {
   SAVE_FINANCE_RECORD_SYMBOL,
   type SaveFinanceRecordProvider,
 } from '@features/financeRecords/providers/saveFinanceRecordProvider'
-import {
-  SEARCH_FINANCE_RECORDS_SYMBOL,
-  type SearchFinanceRecordsProvider,
-} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
 
 import { getFormErrorsFromAPIResponse } from '@shared/services/apiClient/utils'
 import { getInitialFormErrors } from '@shared/utils/form'
@@ -34,10 +29,7 @@ import {
 } from '@features/financeRecords/utils/mappers'
 
 const saveProvider = inject(SAVE_FINANCE_RECORD_SYMBOL) as SaveFinanceRecordProvider
-const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
-const queryKey = computed(() => financeRecordQueryKeys.listByFilters(searchProvider.filters))
-
-const editMutation = useEditFinanceRecordMutation(queryKey)
+const editMutation = useEditFinanceRecordMutation()
 
 const initialFormState = computed(() => {
   if (!saveProvider.editingFinanceRecord) return getInitialSaveFinanceRecordFormState()

--- a/Okane.Client/src/features/financeRecords/components/FinanceRecordList.vue
+++ b/Okane.Client/src/features/financeRecords/components/FinanceRecordList.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // External
-import { computed, inject } from 'vue'
+import { computed } from 'vue'
 
 // Internal
 import FinanceRecordListItem from '@features/financeRecords/components/FinanceRecordListItem.vue'
@@ -11,15 +11,9 @@ import { SHARED_COPY } from '@shared/constants/copy'
 
 import { useInfiniteQueryFinanceRecords } from '@features/financeRecords/composables/useInfiniteQueryFinanceRecords'
 
-import {
-  SEARCH_FINANCE_RECORDS_SYMBOL,
-  type SearchFinanceRecordsProvider,
-} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
-
 import { flattenPages } from '@shared/utils/pagination'
 
-const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
-const queryResult = useInfiniteQueryFinanceRecords(() => searchProvider.filters)
+const queryResult = useInfiniteQueryFinanceRecords()
 const financeRecords = computed(() => flattenPages(queryResult.data.value?.pages))
 </script>
 

--- a/Okane.Client/src/features/financeRecords/components/SearchFinanceRecordsForm.vue
+++ b/Okane.Client/src/features/financeRecords/components/SearchFinanceRecordsForm.vue
@@ -42,7 +42,7 @@ function handleCancel() {
 }
 
 function handleReset() {
-  formState.value = { ...DEFAULT_FINANCE_RECORDS_SEARCH_FILTERS }
+  formState.value = { ...searchProvider.filters }
 }
 
 function handleSubmit() {
@@ -107,7 +107,7 @@ function handleSubmit() {
           {{ SHARED_COPY.ACTIONS.CANCEL }}
         </button>
 
-        <button class="reset-button" @click="handleReset" :type="BUTTON_TYPE.RESET">
+        <button class="reset-button" @click.prevent="handleReset" :type="BUTTON_TYPE.RESET">
           {{ SHARED_COPY.ACTIONS.RESET }}
         </button>
       </ModalActions>

--- a/Okane.Client/src/features/financeRecords/components/TotalAmountCell.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/TotalAmountCell.spec.ts
@@ -1,0 +1,35 @@
+// Internal
+import TotalAmountCell from '@features/financeRecords/components/TotalAmountCell.vue'
+
+import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
+
+const mountComponent = getMountComponent(TotalAmountCell)
+
+const props = {
+  amount: 1000,
+  count: 5,
+  headingText: 'Revenue',
+}
+
+test('renders the heading', () => {
+  const wrapper = mountComponent({ props })
+  expect(wrapper.findByText('h4', props.headingText)).toBeDefined()
+})
+
+test('renders the amount', () => {
+  const wrapper = mountComponent({ props })
+  expect(wrapper.findByText('p', `$${props.amount}.00`)).toBeDefined()
+})
+
+test('renders the records count', () => {
+  let wrapper = mountComponent({ props })
+  expect(wrapper.findByText('p', `${props.count} ${FINANCES_COPY.STATS.RECORD}s`)).toBeDefined()
+
+  wrapper = mountComponent({
+    props: {
+      ...props,
+      count: 1,
+    },
+  })
+  expect(wrapper.findByText('p', `1 ${FINANCES_COPY.STATS.RECORD}`)).toBeDefined()
+})

--- a/Okane.Client/src/features/financeRecords/components/TotalAmountCell.vue
+++ b/Okane.Client/src/features/financeRecords/components/TotalAmountCell.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+// Internal
+import Heading from '@shared/components/Heading.vue'
+
+import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
+
+import { pluralize } from '@shared/utils/string'
+
+type Props = {
+  amount: number
+  count: number
+  headingText: string
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <div class="cell">
+    <Heading class="heading" tag="h4">{{ props.headingText }}</Heading>
+    <p class="amount">${{ props.amount.toFixed(2) }}</p>
+    <p class="count">
+      {{ props.count }}
+      {{ pluralize({ text: FINANCES_COPY.STATS.RECORD, count: props.count, suffix: 's' }) }}
+    </p>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.cell {
+  flex-grow: 1;
+  padding-block: var(--space-lg);
+  text-align: center;
+
+  & > * + * {
+    margin-top: var(--space-xs);
+  }
+}
+
+.amount {
+  font-size: var(--font-size-md);
+}
+
+.heading {
+  margin-block: 0;
+}
+
+.count {
+  font-size: var(--font-size-sm);
+}
+</style>

--- a/Okane.Client/src/features/financeRecords/components/TotalRevenueAndExpenses.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/TotalRevenueAndExpenses.spec.ts
@@ -1,0 +1,126 @@
+// External
+import { flushPromises, VueWrapper } from '@vue/test-utils'
+import { http, HttpResponse } from 'msw'
+
+// Internal
+import Heading from '@shared/components/Heading.vue'
+import TotalAmountCell from '@features/financeRecords/components/TotalAmountCell.vue'
+import TotalRevenueAndExpenses from '@features/financeRecords/components/TotalRevenueAndExpenses.vue'
+
+import { DEFAULT_FINANCE_RECORDS_SEARCH_FILTERS } from '@features/financeRecords/constants/searchFinanceRecords'
+import { HTML_ROLE } from '@shared/constants/html'
+import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
+import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRoutes'
+
+import { type FinanceRecordsStats } from '@features/financeRecords/types/financeRecordsStats'
+
+import {
+  SEARCH_FINANCE_RECORDS_SYMBOL,
+  useSearchFinanceRecordsProvider,
+} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
+
+import { pluralize } from '@shared/utils/string'
+
+import { getMSWURL } from '@tests/utils/url'
+import { testServer } from '@tests/msw/testServer'
+import { wrapInAPIResponse } from '@tests/utils/apiResponse'
+
+const mountComponent = getMountComponent(TotalRevenueAndExpenses, {
+  global: {
+    provide: {
+      [SEARCH_FINANCE_RECORDS_SYMBOL]: useSearchFinanceRecordsProvider(),
+    },
+  },
+  withQueryClient: true,
+})
+
+function useStatsHandler(stats: FinanceRecordsStats) {
+  const url = getMSWURL(
+    financeRecordAPIRoutes.getStats({
+      searchFilters: DEFAULT_FINANCE_RECORDS_SEARCH_FILTERS,
+    }),
+  )
+  testServer.use(http.get(url, () => HttpResponse.json(wrapInAPIResponse(stats))))
+}
+
+const sharedTests = {
+  async rendersACell(args: {
+    amount: number
+    count: number
+    getCell: (cells: VueWrapper[]) => VueWrapper
+    headingText: string
+    stats: FinanceRecordsStats
+  }) {
+    useStatsHandler(args.stats)
+    const wrapper = mountComponent()
+    await flushPromises()
+
+    const cells = wrapper.findAllComponents(TotalAmountCell)
+    const cell = args.getCell(cells)
+    const heading = cell.findComponent(Heading)
+    expect(heading.text()).toBe(args.headingText)
+
+    const amount = cell.findByText('p', `$${args.amount.toFixed(2)}`)
+    expect(amount).toBeDefined()
+
+    const countText = pluralize({
+      text: FINANCES_COPY.STATS.RECORD,
+      count: args.count,
+      suffix: 's',
+    })
+
+    const count = cell.findByText('p', countText)
+    expect(count).toBeDefined()
+  },
+}
+
+const defaultStats: FinanceRecordsStats = {
+  expenseRecords: 10,
+  totalExpenses: 100.1,
+  revenueRecords: 20,
+  totalRevenue: 200.5,
+}
+
+test('renders a divider', () => {
+  useStatsHandler(defaultStats)
+
+  const wrapper = mountComponent()
+  expect(wrapper.find(`div[role="${HTML_ROLE.SEPARATOR}"]`).exists()).toBe(true)
+})
+
+test('renders revenue stats', async () => {
+  await sharedTests.rendersACell({
+    amount: defaultStats.totalRevenue,
+    count: defaultStats.revenueRecords,
+    stats: defaultStats,
+    headingText: FINANCES_COPY.RECORD_TYPES.REVENUE,
+    getCell: (cells) => cells[0],
+  })
+})
+
+test('renders expense stats', async () => {
+  await sharedTests.rendersACell({
+    amount: defaultStats.totalExpenses,
+    count: defaultStats.expenseRecords,
+    stats: defaultStats,
+    headingText: FINANCES_COPY.STATS.EXPENSES,
+    getCell: (cells) => cells[1],
+  })
+})
+
+test('renders default amounts and counts while fetching stats', () => {
+  useStatsHandler(defaultStats)
+
+  const wrapper = mountComponent()
+  const cells = wrapper.findAllComponents(TotalAmountCell)
+  const defaultAmount = '$0.00'
+  const defaultCount = `0 ${FINANCES_COPY.STATS.RECORD}s`
+
+  cells.forEach((cell) => {
+    const amount = cell.findByText('p', defaultAmount)
+    expect(amount).toBeDefined()
+
+    const count = cell.findByText('p', defaultCount)
+    expect(count).toBeDefined()
+  })
+})

--- a/Okane.Client/src/features/financeRecords/components/TotalRevenueAndExpenses.vue
+++ b/Okane.Client/src/features/financeRecords/components/TotalRevenueAndExpenses.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+// External
+import { computed } from 'vue'
+
+// Internal
+import TotalAmountCell from '@features/financeRecords/components/TotalAmountCell.vue'
+
+import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
+
+import { useQueryFinanceRecordsStats } from '@features/financeRecords/composables/useQueryFinanceRecordsStats'
+
+const { data } = useQueryFinanceRecordsStats()
+const stats = computed(() => data.value?.items[0])
+</script>
+
+<template>
+  <section class="root">
+    <TotalAmountCell
+      :amount="stats?.totalRevenue ?? 0"
+      :count="stats?.revenueRecords ?? 0"
+      :heading-text="FINANCES_COPY.RECORD_TYPES.REVENUE"
+    />
+    <div class="divider" role="separator" />
+    <TotalAmountCell
+      :amount="stats?.totalExpenses ?? 0"
+      :count="stats?.expenseRecords ?? 0"
+      :heading-text="FINANCES_COPY.STATS.EXPENSES"
+    />
+  </section>
+</template>
+
+<style scoped lang="scss">
+.root {
+  border: pxToRem(1) solid var(--color-gray-500);
+  display: flex;
+}
+
+.divider {
+  background-color: var(--color-gray-500);
+  width: pxToRem(1);
+}
+</style>

--- a/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.spec.ts
@@ -1,11 +1,18 @@
 // External
-import { defineComponent, toRef } from 'vue'
 import { flushPromises } from '@vue/test-utils'
+import { defineComponent } from 'vue'
 
 // Internal
 import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRoutes'
+import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
 
 import { useCreateFinanceRecordMutation } from '@features/financeRecords/composables/useCreateFinanceRecordMutation'
+
+import {
+  SEARCH_FINANCE_RECORDS_SYMBOL,
+  type SearchFinanceRecordsProvider,
+  useSearchFinanceRecordsProvider,
+} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
 
 import { apiClient } from '@shared/services/apiClient/apiClient'
 
@@ -24,27 +31,35 @@ const spyOn = {
   },
 }
 
-const queryKey = toRef(['a'])
-
 const TestComponent = defineComponent({
   props: {
     shouldPassSearchFilters: Boolean,
   },
   setup() {
-    const mutation = useCreateFinanceRecordMutation(queryKey)
+    const mutation = useCreateFinanceRecordMutation()
     mutation.mutate(financeRecord)
   },
   template: '<div />',
 })
 
-function mountComponent() {
-  return getMountComponent(TestComponent, { withQueryClient: true })()
+function mountWithProviders(args: { searchProvider?: SearchFinanceRecordsProvider } = {}) {
+  let searchProvider = args.searchProvider
+  if (!searchProvider) searchProvider = useSearchFinanceRecordsProvider()
+
+  return getMountComponent(TestComponent, {
+    global: {
+      provide: {
+        [SEARCH_FINANCE_RECORDS_SYMBOL]: searchProvider,
+      },
+    },
+    withQueryClient: true,
+  })()
 }
 
 test('makes a POST request to the expected endpoint', async () => {
   const postSpy = spyOn.post()
 
-  mountComponent()
+  mountWithProviders()
 
   await flushPromises()
 
@@ -53,12 +68,14 @@ test('makes a POST request to the expected endpoint', async () => {
 
 test('invalidates the query key when search filters are passed', async () => {
   spyOn.post()
-
   const invalidateSpy = spyOn.invalidateQueries()
+  const searchProvider = useSearchFinanceRecordsProvider()
 
-  mountComponent()
+  mountWithProviders({ searchProvider })
 
   await flushPromises()
 
-  expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKey.value })
+  expect(invalidateSpy).toHaveBeenCalledWith({
+    queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
+  })
 })

--- a/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.spec.ts
@@ -66,7 +66,7 @@ test('makes a POST request to the expected endpoint', async () => {
   expect(postSpy).toHaveBeenCalledWith(financeRecordAPIRoutes.postFinanceRecord(), financeRecord)
 })
 
-test('invalidates the query key when search filters are passed', async () => {
+test('invalidates the expected query keys', async () => {
   spyOn.post()
   const invalidateSpy = spyOn.invalidateQueries()
   const searchProvider = useSearchFinanceRecordsProvider()
@@ -75,7 +75,12 @@ test('invalidates the query key when search filters are passed', async () => {
 
   await flushPromises()
 
+  expect(invalidateSpy).toHaveBeenCalledTimes(2)
+
   expect(invalidateSpy).toHaveBeenCalledWith({
     queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
+  })
+  expect(invalidateSpy).toHaveBeenCalledWith({
+    queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
   })
 })

--- a/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.ts
@@ -1,6 +1,6 @@
 // External
-import { type MaybeRefOrGetter, toValue } from 'vue'
-import { type QueryKey, useMutation, useQueryClient } from '@tanstack/vue-query'
+import { inject } from 'vue'
+import { useMutation, useQueryClient } from '@tanstack/vue-query'
 
 // Internal
 import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRoutes'
@@ -8,18 +8,27 @@ import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRo
 import { type PreCreationFinanceRecord } from '@features/financeRecords/types/saveFinanceRecord'
 
 import { apiClient } from '@shared/services/apiClient/apiClient'
+import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
+
+import {
+  SEARCH_FINANCE_RECORDS_SYMBOL,
+  type SearchFinanceRecordsProvider,
+} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
 
 function postFinanceRecord(financeRecord: PreCreationFinanceRecord) {
   return apiClient.post(financeRecordAPIRoutes.postFinanceRecord(), financeRecord)
 }
 
-export function useCreateFinanceRecordMutation(queryKey: MaybeRefOrGetter<QueryKey>) {
+export function useCreateFinanceRecordMutation() {
   const queryClient = useQueryClient()
+  const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
 
   return useMutation({
     mutationFn: (financeRecord: PreCreationFinanceRecord) => postFinanceRecord(financeRecord),
     onSuccess() {
-      void queryClient.invalidateQueries({ queryKey: toValue(queryKey) })
+      void queryClient.invalidateQueries({
+        queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
+      })
     },
   })
 }

--- a/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.ts
@@ -29,6 +29,10 @@ export function useCreateFinanceRecordMutation() {
       void queryClient.invalidateQueries({
         queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
       })
+
+      void queryClient.invalidateQueries({
+        queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
+      })
     },
   })
 }

--- a/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.spec.ts
@@ -1,9 +1,10 @@
 // External
-import { defineComponent, toRef } from 'vue'
+import { defineComponent } from 'vue'
 import { flushPromises } from '@vue/test-utils'
 
 // Internal
 import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRoutes'
+import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
 
 import { useDeleteFinanceRecordMutation } from '@features/financeRecords/composables/useDeleteFinanceRecordMutation'
 
@@ -14,6 +15,11 @@ import { removeItemFromPages } from '@shared/utils/pagination'
 import { createTestFinanceRecord } from '@tests/factories/financeRecord'
 import { testQueryClient } from '@tests/queryClient/testQueryClient'
 import { wrapInAPIPaginatedResponse, wrapInAPIResponse } from '@tests/utils/apiResponse'
+import {
+  SEARCH_FINANCE_RECORDS_SYMBOL,
+  type SearchFinanceRecordsProvider,
+  useSearchFinanceRecordsProvider,
+} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
 
 const spyOn = {
   delete() {
@@ -22,28 +28,36 @@ const spyOn = {
 }
 
 const financeRecordId = 540
-const queryKey = toRef(['a'])
 
 const TestComponent = defineComponent({
   props: {
     shouldPassSearchFilters: Boolean,
   },
   setup() {
-    const mutation = useDeleteFinanceRecordMutation(queryKey)
+    const mutation = useDeleteFinanceRecordMutation()
     mutation.mutate(financeRecordId)
   },
   template: '<div />',
 })
 
-function mountComponent() {
-  return getMountComponent(TestComponent, { withQueryClient: true })()
+function mountWithProviders(args: { searchProvider?: SearchFinanceRecordsProvider } = {}) {
+  let searchProvider = args.searchProvider
+  if (!searchProvider) searchProvider = useSearchFinanceRecordsProvider()
+
+  return getMountComponent(TestComponent, {
+    global: {
+      provide: {
+        [SEARCH_FINANCE_RECORDS_SYMBOL]: searchProvider,
+      },
+    },
+    withQueryClient: true,
+  })()
 }
 
 test('makes a DELETE request to the expected endpoint', async () => {
   const deleteSpy = spyOn.delete()
 
-  mountComponent()
-
+  mountWithProviders()
   await flushPromises()
 
   expect(deleteSpy).toHaveBeenCalledWith(
@@ -65,15 +79,15 @@ test('removes the finance record from the query cache', async () => {
     pageParams: [],
   }
 
-  testQueryClient.setQueryData(queryKey.value, initialCachedData)
+  const searchProvider = useSearchFinanceRecordsProvider()
+  const queryKey = financeRecordQueryKeys.listByFilters(searchProvider.filters)
 
+  testQueryClient.setQueryData(queryKey, initialCachedData)
   spyOn.delete()
-
-  mountComponent()
-
+  mountWithProviders({ searchProvider })
   await flushPromises()
 
-  const cachedData = testQueryClient.getQueryData(queryKey.value)
+  const cachedData = testQueryClient.getQueryData(queryKey)
   expect(cachedData).toEqual(
     removeItemFromPages(initialCachedData, (item) => item.id !== financeRecordId),
   )

--- a/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.ts
@@ -1,9 +1,9 @@
 // External
-import { toValue, type MaybeRefOrGetter } from 'vue'
-import { useMutation, useQueryClient, type InfiniteData, type QueryKey } from '@tanstack/vue-query'
+import { useMutation, useQueryClient, type InfiniteData } from '@tanstack/vue-query'
 
 // Internal
 import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRoutes'
+import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
 
 import { apiClient } from '@shared/services/apiClient/apiClient'
 
@@ -11,19 +11,21 @@ import type { APIPaginatedResponse } from '@shared/services/apiClient/types'
 import type { FinanceRecord } from '@features/financeRecords/types/financeRecord'
 
 import { removeItemFromPages } from '@shared/utils/pagination'
+import { useSearchFinanceRecordsProvider } from '@features/financeRecords/providers/searchFinanceRecordsProvider'
 
 function deleteFinanceRecord(id: number) {
   return apiClient.delete(financeRecordAPIRoutes.deleteFinanceRecord({ id }))
 }
 
-export function useDeleteFinanceRecordMutation(queryKey: MaybeRefOrGetter<QueryKey>) {
+export function useDeleteFinanceRecordMutation() {
   const queryClient = useQueryClient()
+  const searchProvider = useSearchFinanceRecordsProvider()
 
   return useMutation({
     mutationFn: (id: number) => deleteFinanceRecord(id),
     onSuccess(_, id) {
       queryClient.setQueryData<InfiniteData<APIPaginatedResponse<FinanceRecord>>>(
-        toValue(queryKey),
+        financeRecordQueryKeys.listByFilters(searchProvider.filters),
         (data) => {
           if (!data) return data
           return removeItemFromPages(data, (item) => item.id !== id)

--- a/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.ts
@@ -31,6 +31,10 @@ export function useDeleteFinanceRecordMutation() {
           return removeItemFromPages(data, (item) => item.id !== id)
         },
       )
+
+      void queryClient.invalidateQueries({
+        queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
+      })
     },
   })
 }

--- a/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.spec.ts
@@ -68,15 +68,20 @@ test('makes a PATCH request to the expected endpoint', async () => {
   patchSpy.mockRestore()
 })
 
-test('invalidates the query key when search filters are passed', async () => {
+test('invalidates the expected query keys', async () => {
   const patchSpy = spyOn.patch()
   const invalidateSpy = spyOn.invalidateQueries()
   const searchProvider = useSearchFinanceRecordsProvider()
 
   mountWithProviders()
   await flushPromises()
+
+  expect(invalidateSpy).toHaveBeenCalledTimes(2)
   expect(invalidateSpy).toHaveBeenCalledWith({
     queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
+  })
+  expect(invalidateSpy).toHaveBeenCalledWith({
+    queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
   })
 
   patchSpy.mockRestore()

--- a/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.ts
@@ -1,11 +1,17 @@
 // External
-import { toValue, type MaybeRefOrGetter } from 'vue'
-import { useMutation, useQueryClient, type QueryKey } from '@tanstack/vue-query'
+import { inject } from 'vue'
+import { useMutation, useQueryClient } from '@tanstack/vue-query'
 
 // Internal
 import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRoutes'
+import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
 
 import { type FinanceRecord } from '@features/financeRecords/types/financeRecord'
+
+import {
+  SEARCH_FINANCE_RECORDS_SYMBOL,
+  type SearchFinanceRecordsProvider,
+} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
 
 import { apiClient } from '@shared/services/apiClient/apiClient'
 
@@ -18,13 +24,16 @@ type MutationArgs = {
   id: number
 }
 
-export function useEditFinanceRecordMutation(queryKey: MaybeRefOrGetter<QueryKey>) {
+export function useEditFinanceRecordMutation() {
+  const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: (args: MutationArgs) => patchFinanceRecord(args.id, args.changes),
     onSuccess() {
-      void queryClient.invalidateQueries({ queryKey: toValue(queryKey) })
+      void queryClient.invalidateQueries({
+        queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
+      })
     },
   })
 }

--- a/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.ts
@@ -34,6 +34,9 @@ export function useEditFinanceRecordMutation() {
       void queryClient.invalidateQueries({
         queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
       })
+      void queryClient.invalidateQueries({
+        queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
+      })
     },
   })
 }

--- a/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.ts
@@ -1,5 +1,5 @@
 // External
-import { computed, toValue, type MaybeRefOrGetter } from 'vue'
+import { computed, inject } from 'vue'
 
 import { type QueryFunctionContext, useInfiniteQuery } from '@tanstack/vue-query'
 
@@ -13,6 +13,11 @@ import { type FinanceRecord } from '@features/financeRecords/types/financeRecord
 import { type FinanceRecordsSearchFilters } from '@features/financeRecords/types/searchFinanceRecords'
 
 import { useCleanUpInfiniteQuery } from '@shared/composables/useCleanUpInfiniteQuery'
+
+import {
+  SEARCH_FINANCE_RECORDS_SYMBOL,
+  type SearchFinanceRecordsProvider,
+} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
 
 import { apiClient } from '@shared/services/apiClient/apiClient'
 
@@ -29,15 +34,13 @@ export function fetchPaginatedFinanceRecords({
   return apiClient.get(url, { signal })
 }
 
-export function useInfiniteQueryFinanceRecords(
-  searchFilters: MaybeRefOrGetter<FinanceRecordsSearchFilters>,
-) {
-  const queryKey = computed(() => financeRecordQueryKeys.listByFilters(toValue(searchFilters)))
+export function useInfiniteQueryFinanceRecords() {
+  const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
+  const queryKey = computed(() => financeRecordQueryKeys.listByFilters(searchProvider.filters))
 
   useCleanUpInfiniteQuery(queryKey)
 
   return useInfiniteQuery({
-    enabled: Boolean(toValue(searchFilters)),
     queryKey,
     queryFn: fetchPaginatedFinanceRecords,
     initialPageParam: INITIAL_PAGE,

--- a/Okane.Client/src/features/financeRecords/composables/useQueryFinanceRecordsStats.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useQueryFinanceRecordsStats.spec.ts
@@ -1,0 +1,53 @@
+// External
+import { defineComponent, toValue } from 'vue'
+
+// Internal
+import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRoutes'
+import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
+import { INITIAL_PAGE } from '@shared/constants/request'
+
+import { useQueryFinanceRecordsStats } from '@features/financeRecords/composables/useQueryFinanceRecordsStats'
+
+import { apiClient } from '@shared/services/apiClient/apiClient'
+
+import { wrapInAPIResponse } from '@tests/utils/apiResponse'
+import {
+  SEARCH_FINANCE_RECORDS_SYMBOL,
+  type SearchFinanceRecordsProvider,
+  useSearchFinanceRecordsProvider,
+} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
+
+function getTestComponent() {
+  return defineComponent({
+    setup() {
+      useQueryFinanceRecordsStats()
+    },
+    template: '<div />',
+  })
+}
+
+function mountWithProviders(args: { searchProvider?: SearchFinanceRecordsProvider } = {}) {
+  let searchProvider = args.searchProvider
+  if (!searchProvider) searchProvider = useSearchFinanceRecordsProvider()
+
+  return getMountComponent(getTestComponent(), {
+    global: {
+      provide: {
+        [SEARCH_FINANCE_RECORDS_SYMBOL]: searchProvider,
+      },
+    },
+    withQueryClient: true,
+  })()
+}
+
+test('makes a request to fetch stats for finance records', () => {
+  const getSpy = vi.spyOn(apiClient, 'get').mockResolvedValue(wrapInAPIResponse({}))
+  const searchProvider = useSearchFinanceRecordsProvider()
+
+  mountWithProviders({ searchProvider })
+
+  expect(getSpy).toHaveBeenCalledWith(
+    financeRecordAPIRoutes.getStats({ searchFilters: searchProvider.filters }),
+    { signal: new AbortController().signal },
+  )
+})

--- a/Okane.Client/src/features/financeRecords/composables/useQueryFinanceRecordsStats.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useQueryFinanceRecordsStats.ts
@@ -1,0 +1,36 @@
+// External
+import { computed, inject } from 'vue'
+import { useQuery, type QueryFunctionContext } from '@tanstack/vue-query'
+
+// Internal
+import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRoutes'
+import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
+
+import { type FinanceRecordsSearchFilters } from '@features/financeRecords/types/searchFinanceRecords'
+import { type FinanceRecordsStats } from '@features/financeRecords/types/financeRecordsStats'
+import { type APIResponse } from '@shared/services/apiClient/types'
+
+import {
+  SEARCH_FINANCE_RECORDS_SYMBOL,
+  type SearchFinanceRecordsProvider,
+} from '@features/financeRecords/providers/searchFinanceRecordsProvider'
+
+import { apiClient } from '@shared/services/apiClient/apiClient'
+
+function fetchStats({
+  queryKey,
+  signal,
+}: QueryFunctionContext): Promise<APIResponse<FinanceRecordsStats>> {
+  const searchFilters = queryKey[queryKey.length - 1] as FinanceRecordsSearchFilters
+  return apiClient.get(financeRecordAPIRoutes.getStats({ searchFilters }), { signal })
+}
+
+export function useQueryFinanceRecordsStats() {
+  const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
+  const queryKey = computed(() => financeRecordQueryKeys.stats(searchProvider.filters))
+
+  return useQuery({
+    queryKey,
+    queryFn: fetchStats,
+  })
+}

--- a/Okane.Client/src/features/financeRecords/constants/apiRoutes.ts
+++ b/Okane.Client/src/features/financeRecords/constants/apiRoutes.ts
@@ -21,6 +21,10 @@ export const financeRecordAPIRoutes = {
 
     return `${basePath}?${searchParams.toString()}`
   },
+  getStats(args: { searchFilters: FinanceRecordsSearchFilters }) {
+    const searchParams = mapFinanceRecordsSearchFilters.to.URLSearchParams(args.searchFilters)
+    return `${basePath}/stats?${searchParams.toString()}`
+  },
   deleteFinanceRecord: ({ id }: { id: number }) => `${basePath}/${id}`,
   patchFinanceRecord: ({ id }: { id: number }) => `${basePath}/${id}`,
   postFinanceRecord: () => basePath,

--- a/Okane.Client/src/features/financeRecords/constants/copy.ts
+++ b/Okane.Client/src/features/financeRecords/constants/copy.ts
@@ -17,6 +17,11 @@ export const FINANCES_COPY = {
     TYPE: 'Type',
   },
 
+  RECORD_TYPES: {
+    EXPENSE: 'Expense',
+    REVENUE: 'Revenue',
+  },
+
   SAVE_FINANCE_RECORD_MODAL: {
     CREATE_FINANCE_RECORD: 'Create Finance Record',
     EDIT_FINANCE_RECORD: 'Edit Finance Record',
@@ -30,5 +35,10 @@ export const FINANCES_COPY = {
     HAPPENED_BEFORE: 'Happened before',
     MAX_AMOUNT: 'Max amount',
     MIN_AMOUNT: 'Min amount',
+  },
+
+  STATS: {
+    EXPENSES: 'Expenses',
+    RECORD: 'record',
   },
 } as const

--- a/Okane.Client/src/features/financeRecords/constants/queryKeys.ts
+++ b/Okane.Client/src/features/financeRecords/constants/queryKeys.ts
@@ -5,6 +5,7 @@ export const queryKeys = {
   all: () => ['all'],
   lists: () => [...queryKeys.all(), 'lists'],
   listByFilters: (filters: FinanceRecordsSearchFilters) => [...queryKeys.lists(), filters],
+  stats: (filters: FinanceRecordsSearchFilters) => [...queryKeys.all(), 'stats', filters],
 }
 
 export const financeRecordQueryKeys = queryKeys

--- a/Okane.Client/src/features/financeRecords/types/financeRecordsStats.ts
+++ b/Okane.Client/src/features/financeRecords/types/financeRecordsStats.ts
@@ -1,0 +1,6 @@
+export type FinanceRecordsStats = {
+  expenseRecords: number
+  revenueRecords: number
+  totalExpenses: number
+  totalRevenue: number
+}

--- a/Okane.Client/src/shared/constants/html.ts
+++ b/Okane.Client/src/shared/constants/html.ts
@@ -1,0 +1,3 @@
+export const HTML_ROLE = {
+  SEPARATOR: 'separator',
+} as const

--- a/Okane.Client/src/shared/pages/FinancesPage.spec.ts
+++ b/Okane.Client/src/shared/pages/FinancesPage.spec.ts
@@ -7,8 +7,6 @@ import FinancesPage from '@shared/pages/FinancesPage.vue'
 import { DEFAULT_FINANCE_RECORDS_SEARCH_FILTERS } from '@features/financeRecords/constants/searchFinanceRecords'
 import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 
-import { type FinanceRecordsSearchFilters } from '@features/financeRecords/types/searchFinanceRecords'
-
 import * as deleteFinanceRecordIdProvider from '@features/financeRecords/providers/deleteFinanceRecordIdProvider'
 import * as saveFinanceRecordProvider from '@features/financeRecords/providers/saveFinanceRecordProvider'
 import * as searchFinanceRecordsProvider from '@features/financeRecords/providers/searchFinanceRecordsProvider'
@@ -21,8 +19,9 @@ const testIds = {
   CreateFinanceRecordModal: 'CreateFinanceRecordModal',
   DeleteFinanceRecordModal: 'DeleteFinanceRecordModal',
   EditFinanceRecordModal: 'EditFinanceRecordModal',
-  Heading: 'Heading',
   FinanceRecordList: 'FinanceRecordList',
+  Heading: 'Heading',
+  TotalRevenueAndExpenses: 'TotalRevenueAndExpenses',
   SearchFiltersSection: 'SearchFiltersSection',
 }
 
@@ -47,6 +46,9 @@ const mountComponent = getMountComponent(FinancesPage, {
       SearchFiltersSection: {
         template: `<div data-testid="${testIds.SearchFiltersSection}" />`,
       },
+      TotalRevenueAndExpenses: {
+        template: `<div data-testid="${testIds.TotalRevenueAndExpenses}" />`,
+      },
     },
   },
 })
@@ -55,6 +57,13 @@ test('renders a page title', () => {
   const wrapper = mountComponent()
   const mainHeading = wrapper.get('h1')
   expect(mainHeading.text()).toBe(FINANCES_COPY.FINANCES)
+})
+
+test('renders total revenue and expenses', () => {
+  commonAsserts.rendersElementWithTestId({
+    testId: testIds.TotalRevenueAndExpenses,
+    wrapper: mountComponent(),
+  })
 })
 
 test('renders a list of finance records', () => {

--- a/Okane.Client/src/shared/pages/FinancesPage.vue
+++ b/Okane.Client/src/shared/pages/FinancesPage.vue
@@ -11,6 +11,7 @@ import FinanceRecordList from '@features/financeRecords/components/FinanceRecord
 import Heading from '@shared/components/Heading.vue'
 import PageLayout from '@shared/layouts/PageLayout.vue'
 import SearchFiltersSection from '@features/financeRecords/components/SearchFinanceRecordsSection.vue'
+import TotalRevenueAndExpenses from '@features/financeRecords/components/TotalRevenueAndExpenses.vue'
 
 import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 
@@ -35,6 +36,7 @@ provide(SEARCH_FINANCE_RECORDS_SYMBOL, useSearchFinanceRecordsProvider())
 <template>
   <PageLayout>
     <Heading tag="h1">{{ FINANCES_COPY.FINANCES }}</Heading>
+    <TotalRevenueAndExpenses />
     <SearchFiltersSection />
     <FinanceRecordList />
     <AddFinanceRecordButton />

--- a/Okane.Client/src/shared/utils/string.spec.ts
+++ b/Okane.Client/src/shared/utils/string.spec.ts
@@ -95,6 +95,16 @@ describe('isUppercaseString', () => {
   })
 })
 
+describe('pluralize', () => {
+  test('it pluralizes the word with the expected suffix', () => {
+    expect(stringUtils.pluralize({ text: 'record', count: 2, suffix: 's' })).toBe('records')
+  })
+
+  test('it returns the word as-is if the count is 1', () => {
+    expect(stringUtils.pluralize({ text: 'record', count: 1, suffix: 's' })).toBe('record')
+  })
+})
+
 describe('removePrefixCharacters', () => {
   test.each([
     ['ABCD', 'A', 'BCD'],

--- a/Okane.Client/src/shared/utils/string.ts
+++ b/Okane.Client/src/shared/utils/string.ts
@@ -110,3 +110,13 @@ export function removePrefixCharacters(s: string, prefixCharacter: string): stri
 
   return s.slice(startIdx)
 }
+
+/**
+ * Conditionally pluralize a string if amount isn't  1.
+ *
+ * @param args
+ */
+export function pluralize(args: { text: string; count?: number; suffix: string }): string {
+  if (args.count == 1) return args.text
+  return `${args.text}${args.suffix}`
+}


### PR DESCRIPTION
## Description
- fetch and display stats for finance records
- update composables to inject search filters rather than passing a parameter
    + these composables will only ever be used on the finances page, so no need to worry about a missing `provide`

![finance-record-stats](https://github.com/user-attachments/assets/4edd6cfe-cd18-48f7-91df-2feeabd4c1ae)


## Linked issues
#73