### PR TITLE
Issue 83: Update query key funcs to take an object ARG

### DIFF
--- a/Okane.Client/src/features/financeRecords/components/DeleteFinanceRecordModal.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/DeleteFinanceRecordModal.spec.ts
@@ -1,6 +1,5 @@
 // External
 import { flushPromises } from '@vue/test-utils'
-import { toValue } from 'vue'
 
 import { type HttpHandler } from 'msw'
 
@@ -9,7 +8,6 @@ import DeleteFinanceRecordModal from '@features/financeRecords/components/Delete
 import ModalHeading from '@shared/components/modal/ModalHeading.vue'
 
 import { DEFAULT_FINANCE_RECORDS_SEARCH_FILTERS } from '@features/financeRecords/constants/searchFinanceRecords'
-import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
 import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 import { SHARED_COPY } from '@shared/constants/copy'
 
@@ -30,7 +28,6 @@ import { financeRecordHandlers } from '@tests/msw/handlers/financeRecord'
 import { testServer } from '@tests/msw/testServer'
 
 const financeRecordId = 540
-const searchFilters = DEFAULT_FINANCE_RECORDS_SEARCH_FILTERS
 const mountComponent = getMountComponent(DeleteFinanceRecordModal, {
   global: {
     provide: {

--- a/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.spec.ts
@@ -78,9 +78,9 @@ test('invalidates the expected query keys', async () => {
   expect(invalidateSpy).toHaveBeenCalledTimes(2)
 
   expect(invalidateSpy).toHaveBeenCalledWith({
-    queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
+    queryKey: financeRecordQueryKeys.listByFilters({ filters: searchProvider.filters }),
   })
   expect(invalidateSpy).toHaveBeenCalledWith({
-    queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
+    queryKey: financeRecordQueryKeys.stats({ filters: searchProvider.filters }),
   })
 })

--- a/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useCreateFinanceRecordMutation.ts
@@ -27,11 +27,11 @@ export function useCreateFinanceRecordMutation() {
     mutationFn: (financeRecord: PreCreationFinanceRecord) => postFinanceRecord(financeRecord),
     onSuccess() {
       void queryClient.invalidateQueries({
-        queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
+        queryKey: financeRecordQueryKeys.listByFilters({ filters: searchProvider.filters }),
       })
 
       void queryClient.invalidateQueries({
-        queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
+        queryKey: financeRecordQueryKeys.stats({ filters: searchProvider.filters }),
       })
     },
   })

--- a/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.spec.ts
@@ -81,7 +81,7 @@ test('removes the finance record from the query cache', async () => {
   }
 
   const searchProvider = useSearchFinanceRecordsProvider()
-  const queryKey = financeRecordQueryKeys.listByFilters(searchProvider.filters)
+  const queryKey = financeRecordQueryKeys.listByFilters({ filters: searchProvider.filters })
 
   testQueryClient.setQueryData(queryKey, initialCachedData)
   spyOn.delete()
@@ -103,7 +103,7 @@ test('invalidates the stats key', async () => {
   await flushPromises()
 
   expect(invalidateSpy).toHaveBeenCalledWith({
-    queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
+    queryKey: financeRecordQueryKeys.stats({ filters: searchProvider.filters }),
   })
 
   invalidateSpy.mockRestore()

--- a/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useDeleteFinanceRecordMutation.ts
@@ -25,7 +25,7 @@ export function useDeleteFinanceRecordMutation() {
     mutationFn: (id: number) => deleteFinanceRecord(id),
     onSuccess(_, id) {
       queryClient.setQueryData<InfiniteData<APIPaginatedResponse<FinanceRecord>>>(
-        financeRecordQueryKeys.listByFilters(searchProvider.filters),
+        financeRecordQueryKeys.listByFilters({ filters: searchProvider.filters }),
         (data) => {
           if (!data) return data
           return removeItemFromPages(data, (item) => item.id !== id)
@@ -33,7 +33,7 @@ export function useDeleteFinanceRecordMutation() {
       )
 
       void queryClient.invalidateQueries({
-        queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
+        queryKey: financeRecordQueryKeys.stats({ filters: searchProvider.filters }),
       })
     },
   })

--- a/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.spec.ts
@@ -78,10 +78,10 @@ test('invalidates the expected query keys', async () => {
 
   expect(invalidateSpy).toHaveBeenCalledTimes(2)
   expect(invalidateSpy).toHaveBeenCalledWith({
-    queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
+    queryKey: financeRecordQueryKeys.listByFilters({ filters: searchProvider.filters }),
   })
   expect(invalidateSpy).toHaveBeenCalledWith({
-    queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
+    queryKey: financeRecordQueryKeys.stats({ filters: searchProvider.filters }),
   })
 
   patchSpy.mockRestore()

--- a/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useEditFinanceRecordMutation.ts
@@ -32,10 +32,10 @@ export function useEditFinanceRecordMutation() {
     mutationFn: (args: MutationArgs) => patchFinanceRecord(args.id, args.changes),
     onSuccess() {
       void queryClient.invalidateQueries({
-        queryKey: financeRecordQueryKeys.listByFilters(searchProvider.filters),
+        queryKey: financeRecordQueryKeys.listByFilters({ filters: searchProvider.filters }),
       })
       void queryClient.invalidateQueries({
-        queryKey: financeRecordQueryKeys.stats(searchProvider.filters),
+        queryKey: financeRecordQueryKeys.stats({ filters: searchProvider.filters }),
       })
     },
   })

--- a/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.spec.ts
@@ -66,7 +66,7 @@ test('cleans up the infinite query', () => {
   mountWithProviders()
 
   expect(toValue(cleanUpSpy.mock.calls[0][0])).toEqual(
-    financeRecordQueryKeys.listByFilters(searchProvider.filters),
+    financeRecordQueryKeys.listByFilters({ filters: searchProvider.filters }),
   )
 
   getSpy.mockRestore()

--- a/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useInfiniteQueryFinanceRecords.ts
@@ -36,7 +36,9 @@ export function fetchPaginatedFinanceRecords({
 
 export function useInfiniteQueryFinanceRecords() {
   const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
-  const queryKey = computed(() => financeRecordQueryKeys.listByFilters(searchProvider.filters))
+  const queryKey = computed(() =>
+    financeRecordQueryKeys.listByFilters({ filters: searchProvider.filters }),
+  )
 
   useCleanUpInfiniteQuery(queryKey)
 

--- a/Okane.Client/src/features/financeRecords/composables/useQueryFinanceRecordsStats.spec.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useQueryFinanceRecordsStats.spec.ts
@@ -1,10 +1,8 @@
 // External
-import { defineComponent, toValue } from 'vue'
+import { defineComponent } from 'vue'
 
 // Internal
 import { financeRecordAPIRoutes } from '@features/financeRecords/constants/apiRoutes'
-import { financeRecordQueryKeys } from '@features/financeRecords/constants/queryKeys'
-import { INITIAL_PAGE } from '@shared/constants/request'
 
 import { useQueryFinanceRecordsStats } from '@features/financeRecords/composables/useQueryFinanceRecordsStats'
 

--- a/Okane.Client/src/features/financeRecords/composables/useQueryFinanceRecordsStats.ts
+++ b/Okane.Client/src/features/financeRecords/composables/useQueryFinanceRecordsStats.ts
@@ -27,7 +27,7 @@ function fetchStats({
 
 export function useQueryFinanceRecordsStats() {
   const searchProvider = inject(SEARCH_FINANCE_RECORDS_SYMBOL) as SearchFinanceRecordsProvider
-  const queryKey = computed(() => financeRecordQueryKeys.stats(searchProvider.filters))
+  const queryKey = computed(() => financeRecordQueryKeys.stats({ filters: searchProvider.filters }))
 
   return useQuery({
     queryKey,

--- a/Okane.Client/src/features/financeRecords/constants/queryKeys.ts
+++ b/Okane.Client/src/features/financeRecords/constants/queryKeys.ts
@@ -4,8 +4,8 @@ import { type FinanceRecordsSearchFilters } from '@features/financeRecords/types
 export const queryKeys = {
   all: () => ['all'],
   lists: () => [...queryKeys.all(), 'lists'],
-  listByFilters: (filters: FinanceRecordsSearchFilters) => [...queryKeys.lists(), filters],
-  stats: (filters: FinanceRecordsSearchFilters) => [...queryKeys.all(), 'stats', filters],
+  listByFilters: (args: { filters: FinanceRecordsSearchFilters }) => [...queryKeys.lists(), args.filters],
+  stats: (args: { filters: FinanceRecordsSearchFilters }) => [...queryKeys.all(), 'stats', args.filters],
 }
 
 export const financeRecordQueryKeys = queryKeys


### PR DESCRIPTION
## Description
Update `financeRecordQueryKeys` funcs to take a single object ARG. Done for consistency with some other object constants (e.g. API routes).


## Linked issues
#83