### PR TITLE
Issue 40: Update frontend to use API password requirements

### DIFF
--- a/Okane.Api.Tests/Features/Auth/Endpoints/GetPasswordRequirementsTests.cs
+++ b/Okane.Api.Tests/Features/Auth/Endpoints/GetPasswordRequirementsTests.cs
@@ -1,0 +1,23 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Okane.Api.Features.Auth.Dtos.Responses;
+using Okane.Api.Shared.Dtos.ApiResponses;
+using Okane.Api.Tests.Testing.Integration;
+
+namespace Okane.Api.Tests.Features.Auth.Endpoints;
+
+public class GetPasswordRequirementsTests(PostgresApiFactory apiFactory) : DatabaseTest(apiFactory)
+{
+    private readonly HttpClient _client = apiFactory.CreateClient();
+
+    [Fact]
+    public async Task ReturnsThePasswordRequirements()
+    {
+        var response = await _client.GetAsync("/auth/password-requirements");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<ApiResponse<PasswordRequirementsResponse>>();
+        body?.Items.Should().NotBeNull().And.HaveCount(1);
+    }
+}

--- a/Okane.Api/Features/Auth/Constants/AuthEndpointNames.cs
+++ b/Okane.Api/Features/Auth/Constants/AuthEndpointNames.cs
@@ -2,6 +2,7 @@ namespace Okane.Api.Features.Auth.Constants;
 
 public static class AuthEndpointNames
 {
+    public const string GetPasswordRequirements = "GetPasswordRequirements";
     public const string GetSelf = "GetSelf";
     public const string Login = "Login";
     public const string Logout = "Logout";

--- a/Okane.Api/Features/Auth/Dtos/Responses/PasswordRequirementsResponse.cs
+++ b/Okane.Api/Features/Auth/Dtos/Responses/PasswordRequirementsResponse.cs
@@ -1,0 +1,10 @@
+namespace Okane.Api.Features.Auth.Dtos.Responses;
+
+public record PasswordRequirementsResponse
+{
+    public int MinLength { get; set; }
+    public bool RequireDigit { get; set; }
+    public bool RequireLowercase { get; set; }
+    public bool RequireUppercase { get; set; }
+    public bool RequireNonAlphanumeric { get; set; }
+}

--- a/Okane.Api/Features/Auth/Endpoints/GetPasswordRequirements.cs
+++ b/Okane.Api/Features/Auth/Endpoints/GetPasswordRequirements.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Okane.Api.Features.Auth.Constants;
+using Okane.Api.Features.Auth.Dtos.Responses;
+using Okane.Api.Features.Auth.Mappers;
+using Okane.Api.Infrastructure.Endpoints;
+using Okane.Api.Shared.Dtos.ApiResponses;
+
+namespace Okane.Api.Features.Auth.Endpoints;
+
+public class GetPasswordRequirements : IEndpoint
+{
+    public static void Map(IEndpointRouteBuilder builder)
+    {
+        builder
+            .MapGet("/password-requirements", Handle)
+            .AllowAnonymous()
+            .WithName(AuthEndpointNames.GetPasswordRequirements)
+            .WithSummary("Get the configured password requirements.");
+    }
+
+    private static Ok<ApiResponse<PasswordRequirementsResponse>> Handle(IOptions<IdentityOptions> identityOptions)
+    {
+        return TypedResults.Ok(new ApiResponse<PasswordRequirementsResponse>(
+            identityOptions.Value.Password.ToPasswordRequirementsResponse()
+        ));
+    }
+}

--- a/Okane.Api/Features/Auth/Mappers/PasswordOptionsMappers.cs
+++ b/Okane.Api/Features/Auth/Mappers/PasswordOptionsMappers.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Identity;
+using Okane.Api.Features.Auth.Dtos.Responses;
+
+namespace Okane.Api.Features.Auth.Mappers;
+
+public static class PasswordOptionsMappers
+{
+    /// <summary>
+    ///     Map a PasswordOptions to a PasswordRequirementsResponse.
+    /// </summary>
+    /// <param name="options"></param>
+    public static PasswordRequirementsResponse ToPasswordRequirementsResponse(this PasswordOptions options)
+    {
+        return new PasswordRequirementsResponse
+        {
+            MinLength = options.RequiredLength,
+            RequireDigit = options.RequireDigit,
+            RequireLowercase = options.RequireLowercase,
+            RequireUppercase = options.RequireUppercase,
+            RequireNonAlphanumeric = options.RequireNonAlphanumeric
+        };
+    }
+}

--- a/Okane.Api/Infrastructure/Endpoints/Endpoints.cs
+++ b/Okane.Api/Infrastructure/Endpoints/Endpoints.cs
@@ -26,6 +26,7 @@ public static class Endpoints
             .MapEndpoint<VerifyEmail>()
             .MapEndpoint<RotateRefreshToken>()
             .MapEndpoint<RevokeRefreshToken>()
+            .MapEndpoint<GetPasswordRequirements>()
             .MapEndpoint<GetSelf>();
 
         endpoints

--- a/Okane.Client/src/__tests__/factories/authForm.ts
+++ b/Okane.Client/src/__tests__/factories/authForm.ts
@@ -1,9 +1,9 @@
 // Internal
 import { baseTestObjectFactory, type TestObjectFactoryFunction } from '@tests/factories/base'
 
-import type { AuthFormState } from '@features/auth/types/authForm'
+import { type AuthFormState, type PasswordRequirements } from '@features/auth/types/authForm'
 
-const defaultState: AuthFormState = {
+const defaultAuthFormState: AuthFormState = {
   email: 'test@okane.com',
   name: 'Okane',
   password: 'coolPassword123',
@@ -14,5 +14,20 @@ export const createTestAuthFormState: TestObjectFactoryFunction<AuthFormState> =
   overrides,
   options,
 ) => {
-  return baseTestObjectFactory(defaultState, overrides, options)
+  return baseTestObjectFactory(defaultAuthFormState, overrides, options)
+}
+
+const defaultPasswordRequirements: PasswordRequirements = {
+  minLength: 12,
+  requireDigit: true,
+  requireLowercase: true,
+  requireUppercase: true,
+  requireNonAlphanumeric: true,
+}
+
+export const createTestPasswordRequirements: TestObjectFactoryFunction<PasswordRequirements> = (
+  overrides,
+  options,
+) => {
+  return baseTestObjectFactory(defaultPasswordRequirements, overrides, options)
 }

--- a/Okane.Client/src/features/auth/components/AuthForm.vue
+++ b/Okane.Client/src/features/auth/components/AuthForm.vue
@@ -4,12 +4,16 @@ import { computed, ref } from 'vue'
 
 // Internal
 import FormInput from '@shared/components/form/FormInput.vue'
+import PasswordRequirements from '@features/auth/components/PasswordRequirements.vue'
 
 import { AUTH_COPY } from '@features/auth/constants/copy'
+import { INPUT_TYPE } from '@shared/constants/form'
 
-import type { AuthFormState, AuthFormType } from '@features/auth/types/authForm'
+import { type AuthFormState, type AuthFormType } from '@features/auth/types/authForm'
 
-import { isValidPassword } from '@features/auth/utils/authForm'
+import { useQueryPasswordRequirements } from '@features/auth/composables/useQueryPasswordRequirements'
+
+import { validatePassword } from '@features/auth/utils/authForm'
 
 const emit = defineEmits<{
   (e: 'submit', formState: AuthFormState): void
@@ -30,18 +34,29 @@ const submitButtonText = computed<string>(() => {
   return AUTH_COPY.LOGIN
 })
 
+const { data: passwordRequirements } = useQueryPasswordRequirements({
+  enabled: isRegisterForm.value,
+})
+
+const validatePasswordResult = computed(() => {
+  if (passwordRequirements.value) {
+    return validatePassword({
+      password: formState.value.password,
+      passwordConfirm: formState.value.passwordConfirm,
+      minPasswordLength: passwordRequirements.value.minLength,
+    })
+  }
+
+  return null
+})
+
 const formIsValid = computed<boolean>(() => {
-  const { email, name, password, passwordConfirm } = formState.value
+  const { email, name, password } = formState.value
 
   const validations = [Boolean(email), Boolean(password)]
 
   if (isRegisterForm.value) {
-    validations.push(
-      Boolean(name),
-      Boolean(passwordConfirm),
-      password == passwordConfirm,
-      isValidPassword(password).isValid,
-    )
+    validations.push(Boolean(name), validatePasswordResult.value?.isValid ?? false)
   }
 
   return !validations.includes(false)
@@ -49,36 +64,44 @@ const formIsValid = computed<boolean>(() => {
 </script>
 
 <template>
-  <form @submit.prevent="emit('submit', formState)">
-    <fieldset>
+  <form v-if="passwordRequirements" class="form" @submit.prevent="emit('submit', formState)">
+    <fieldset class="fieldset">
       <FormInput
         v-if="isRegisterForm"
-        v-model="formState.name"
         :label="AUTH_COPY.AUTH_FORM.NAME"
         name="name"
-        type="text"
+        :type="INPUT_TYPE.TEXT"
+        v-model="formState.name"
       />
 
       <FormInput
         :label="AUTH_COPY.AUTH_FORM.EMAIL"
         name="email"
-        type="email"
+        :type="INPUT_TYPE.EMAIL"
         v-model="formState.email"
-      />
-      <FormInput
-        :label="AUTH_COPY.AUTH_FORM.PASSWORD"
-        name="password"
-        type="password"
-        v-model="formState.password"
       />
 
       <FormInput
-        v-if="isRegisterForm"
-        v-model="formState.passwordConfirm"
-        :label="AUTH_COPY.AUTH_FORM.CONFIRM_PASSWORD"
-        name="passwordConfirm"
-        type="password"
+        :label="AUTH_COPY.AUTH_FORM.PASSWORD"
+        name="password"
+        :type="INPUT_TYPE.PASSWORD"
+        v-model="formState.password"
       />
+
+      <template v-if="isRegisterForm">
+        <FormInput
+          :label="AUTH_COPY.AUTH_FORM.CONFIRM_PASSWORD"
+          name="passwordConfirm"
+          :type="INPUT_TYPE.PASSWORD"
+          v-model="formState.passwordConfirm"
+        />
+
+        <PasswordRequirements
+          v-if="!validatePasswordResult?.isValid"
+          :checks="validatePasswordResult?.passwordChecks ?? {}"
+          :min-password-length="passwordRequirements.minLength"
+        />
+      </template>
 
       <button class="submit-button" :disabled="!formIsValid" type="submit">
         {{ submitButtonText }}
@@ -88,11 +111,11 @@ const formIsValid = computed<boolean>(() => {
 </template>
 
 <style scoped lang="scss">
-form {
+.form {
   max-width: 22rem;
 }
 
-fieldset {
+.fieldset {
   display: flex;
   flex-direction: column;
   gap: var(--space-md);

--- a/Okane.Client/src/features/auth/components/PasswordRequirements.spec.ts
+++ b/Okane.Client/src/features/auth/components/PasswordRequirements.spec.ts
@@ -1,0 +1,184 @@
+// External
+import { type VueWrapper } from '@vue/test-utils'
+
+// Internal
+import Heading from '@shared/components/Heading.vue'
+import PasswordRequirements from '@features/auth/components/PasswordRequirements.vue'
+
+import { AUTH_COPY } from '@features/auth/constants/copy'
+
+import { type PasswordChecks } from '@features/auth/types/authForm'
+
+const mountComponent = getMountComponent(PasswordRequirements)
+const minPasswordLength = 12
+const checks: PasswordChecks = {
+  invalidPasswordConfirm: true,
+  missingNonAlphanumeric: true,
+  missingDigit: true,
+  missingUppercase: true,
+  insufficientLength: true,
+  missingLowercase: true,
+}
+
+const sharedAsserts = {
+  rendersLiWithText(wrapper: VueWrapper, text: string) {
+    const li = wrapper.findByText('li', text)
+    expect(li).toBeDefined()
+  },
+  doesNotRenderLiWithText(wrapper: VueWrapper, text: string) {
+    const li = wrapper.findByText('li', text)
+    expect(li).toBeUndefined()
+  },
+}
+
+test('renders the heading', () => {
+  const wrapper = mountComponent({
+    props: { checks, minPasswordLength },
+  })
+  const heading = wrapper.getComponent(Heading)
+  expect(heading.text()).toBe(AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.HEADING)
+})
+
+test('renders the "insufficient length" text', () => {
+  const wrapper = mountComponent({
+    props: { checks, minPasswordLength },
+  })
+  sharedAsserts.rendersLiWithText(
+    wrapper,
+    AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.MIN_LENGTH(minPasswordLength),
+  )
+})
+
+describe('with a sufficient password length', () => {
+  it('does not render the "insufficient length" text', () => {
+    const wrapper = mountComponent({
+      props: {
+        checks: { ...checks, insufficientLength: false },
+        minPasswordLength,
+      },
+    })
+    sharedAsserts.doesNotRenderLiWithText(
+      wrapper,
+      AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.MIN_LENGTH(minPasswordLength),
+    )
+  })
+})
+
+test('renders the "missing uppercase letter" text', () => {
+  const wrapper = mountComponent({
+    props: { checks, minPasswordLength },
+  })
+  sharedAsserts.rendersLiWithText(
+    wrapper,
+    AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.UPPERCASE_LETTER,
+  )
+})
+
+describe('with an uppercase letter', () => {
+  it('does not render the "missing uppercase letter" text', () => {
+    const wrapper = mountComponent({
+      props: {
+        checks: { ...checks, missingUppercase: false },
+        minPasswordLength,
+      },
+    })
+    sharedAsserts.doesNotRenderLiWithText(
+      wrapper,
+      AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.UPPERCASE_LETTER,
+    )
+  })
+})
+
+test('renders the "missing lowercase letter" text', () => {
+  const wrapper = mountComponent({
+    props: { checks, minPasswordLength },
+  })
+  sharedAsserts.rendersLiWithText(
+    wrapper,
+    AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.LOWERCASE_LETTER,
+  )
+})
+
+describe('with a lowercase letter', () => {
+  it('does not render the "missing lowercase letter" text', () => {
+    const wrapper = mountComponent({
+      props: {
+        checks: { ...checks, missingLowercase: false },
+        minPasswordLength,
+      },
+    })
+    sharedAsserts.doesNotRenderLiWithText(
+      wrapper,
+      AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.LOWERCASE_LETTER,
+    )
+  })
+})
+
+test('renders the "missing digit" text', () => {
+  const wrapper = mountComponent({
+    props: { checks, minPasswordLength },
+  })
+  sharedAsserts.rendersLiWithText(wrapper, AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.DIGIT)
+})
+
+describe('with a digit letter', () => {
+  it('does not render the "missing digit" text', () => {
+    const wrapper = mountComponent({
+      props: {
+        checks: { ...checks, missingDigit: false },
+        minPasswordLength,
+      },
+    })
+    sharedAsserts.doesNotRenderLiWithText(wrapper, AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.DIGIT)
+  })
+})
+
+test('renders the "missing non-alphanumeric symbol" text', () => {
+  const wrapper = mountComponent({
+    props: { checks, minPasswordLength },
+  })
+  sharedAsserts.rendersLiWithText(
+    wrapper,
+    AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.NON_ALPHANUMERIC_SYMBOL,
+  )
+})
+
+describe('with a non-alphanumeric symbol', () => {
+  it('does not render the "missing non-alphanumeric symbol" text', () => {
+    const wrapper = mountComponent({
+      props: {
+        checks: { ...checks, missingNonAlphanumeric: false },
+        minPasswordLength,
+      },
+    })
+    sharedAsserts.doesNotRenderLiWithText(
+      wrapper,
+      AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.NON_ALPHANUMERIC_SYMBOL,
+    )
+  })
+})
+
+test('renders the "invalid password confirm" text', () => {
+  const wrapper = mountComponent({
+    props: { checks, minPasswordLength },
+  })
+  sharedAsserts.rendersLiWithText(
+    wrapper,
+    AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.MATCHING_PASSWORDS,
+  )
+})
+
+describe('with a valid password confirm', () => {
+  it('does not render the "invalid password confirm" text', () => {
+    const wrapper = mountComponent({
+      props: {
+        checks: { ...checks, invalidPasswordConfirm: false },
+        minPasswordLength,
+      },
+    })
+    sharedAsserts.doesNotRenderLiWithText(
+      wrapper,
+      AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS.MATCHING_PASSWORDS,
+    )
+  })
+})

--- a/Okane.Client/src/features/auth/components/PasswordRequirements.vue
+++ b/Okane.Client/src/features/auth/components/PasswordRequirements.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+// Internal
+import Heading from '@shared/components/Heading.vue'
+
+import { AUTH_COPY } from '@features/auth/constants/copy'
+
+import { type PasswordChecks } from '@features/auth/types/authForm'
+
+const copy = AUTH_COPY.AUTH_FORM.PASSWORD_REQUIREMENTS
+
+type Props = {
+  checks: PasswordChecks
+  minPasswordLength: number
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <div>
+    <Heading tag="h3" class="heading">{{ copy.HEADING }}</Heading>
+    <ul class="list">
+      <li v-if="props.checks.insufficientLength">{{ copy.MIN_LENGTH(props.minPasswordLength) }}</li>
+      <li v-if="props.checks.missingUppercase">
+        {{ copy.UPPERCASE_LETTER }}
+      </li>
+      <li v-if="props.checks.missingLowercase">
+        {{ copy.LOWERCASE_LETTER }}
+      </li>
+      <li v-if="props.checks.missingDigit">
+        {{ copy.DIGIT }}
+      </li>
+      <li v-if="props.checks.missingNonAlphanumeric">
+        {{ copy.NON_ALPHANUMERIC_SYMBOL }}
+      </li>
+      <li v-if="props.checks.invalidPasswordConfirm">
+        {{ copy.MATCHING_PASSWORDS }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.heading {
+  font-size: var(--font-size-md);
+  margin-block: 0;
+}
+
+.list {
+  list-style-type: disc;
+
+  /* TODO: Add consistent list spacing. */
+  padding-left: var(--space-md);
+}
+</style>

--- a/Okane.Client/src/features/auth/components/RegisterForm.spec.ts
+++ b/Okane.Client/src/features/auth/components/RegisterForm.spec.ts
@@ -1,24 +1,37 @@
 // External
+import { http, HttpResponse } from 'msw'
 import { flushPromises } from '@vue/test-utils'
 
 // Internal
 import AuthForm from '@features/auth/components/AuthForm.vue'
 import RegisterForm from '@features/auth/components/RegisterForm.vue'
 
+import { authAPIRoutes } from '@features/auth/constants/apiRoutes'
 import { AUTH_COPY } from '@features/auth/constants/copy'
 
 import { useAuthStore } from '@features/auth/composables/useAuthStore'
 import { useMockedStore } from '@tests/composables/useMockedStore'
 
-import { createTestAuthFormState } from '@tests/factories/authForm'
+import { getMSWURL } from '@tests/utils/url'
+import { testServer } from '@tests/msw/testServer'
+import { wrapInAPIResponse } from '@tests/utils/apiResponse'
+import { createTestAuthFormState, createTestPasswordRequirements } from '@tests/factories/authForm'
 import { createAppRouter, appRoutes, ROUTE_NAME } from '@shared/services/router/router'
 
 const router = createAppRouter()
-const mountComponent = getMountComponent(RegisterForm, { withPinia: true, withRouter: router })
+const mountComponent = getMountComponent(RegisterForm, {
+  withRouter: router,
+  withQueryClient: true,
+})
 
 const formData = createTestAuthFormState()
 
 beforeEach(async () => {
+  testServer.use(
+    http.get(getMSWURL(authAPIRoutes.passwordRequirements()), () =>
+      HttpResponse.json(wrapInAPIResponse(createTestPasswordRequirements())),
+    ),
+  )
   await router.push({ name: ROUTE_NAME.REGISTER })
 })
 

--- a/Okane.Client/src/features/auth/composables/useQueryPasswordRequirements.spec.ts
+++ b/Okane.Client/src/features/auth/composables/useQueryPasswordRequirements.spec.ts
@@ -1,0 +1,41 @@
+// External
+import { defineComponent } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+// Internal
+import { authAPIRoutes } from '@features/auth/constants/apiRoutes'
+
+import { useQueryPasswordRequirements } from '@features/auth/composables/useQueryPasswordRequirements'
+
+import { apiClient } from '@shared/services/apiClient/apiClient'
+
+import { wrapInAPIResponse } from '@tests/utils/apiResponse'
+
+const getResponse = 'cool-requirements'
+
+const spyOn = {
+  get() {
+    return vi.spyOn(apiClient, 'get').mockResolvedValue(wrapInAPIResponse(getResponse))
+  },
+}
+
+const TestComponent = defineComponent({
+  setup() {
+    const { data } = useQueryPasswordRequirements()
+    return { data }
+  },
+  template: '<div>{{ data }}</div>',
+})
+
+const mountComponent = getMountComponent(TestComponent, { withQueryClient: true })
+
+test('makes a GET request to the expected endpoint', async () => {
+  const getSpy = spyOn.get()
+
+  const wrapper = mountComponent()
+  await flushPromises()
+  expect(getSpy).toHaveBeenCalledWith(authAPIRoutes.passwordRequirements(), {
+    signal: new AbortController().signal,
+  })
+  expect(wrapper.findByText('div', getResponse)).toBeDefined()
+})

--- a/Okane.Client/src/features/auth/composables/useQueryPasswordRequirements.ts
+++ b/Okane.Client/src/features/auth/composables/useQueryPasswordRequirements.ts
@@ -1,0 +1,26 @@
+// External
+import { useQuery, type QueryFunctionContext } from '@tanstack/vue-query'
+
+// Internal
+import { authQueryKeys } from '@features/auth/constants/queryKeys'
+import { apiClient } from '@shared/services/apiClient/apiClient'
+import { authAPIRoutes } from '@features/auth/constants/apiRoutes'
+
+import { type APIResponse } from '@shared/services/apiClient/types'
+import { type PasswordRequirements } from '@features/auth/types/authForm'
+
+function getPasswordRequirements({
+  signal,
+}: QueryFunctionContext): Promise<APIResponse<PasswordRequirements>> {
+  return apiClient.get(authAPIRoutes.passwordRequirements(), { signal })
+}
+
+export function useQueryPasswordRequirements({ enabled = true } = {}) {
+  return useQuery({
+    enabled,
+    queryKey: authQueryKeys.passwordRequirements(),
+    queryFn: getPasswordRequirements,
+    select: (data) => data.items[0],
+    staleTime: Infinity,
+  })
+}

--- a/Okane.Client/src/features/auth/constants/apiRoutes.ts
+++ b/Okane.Client/src/features/auth/constants/apiRoutes.ts
@@ -4,6 +4,7 @@ const basePath = '/auth'
 export const authAPIRoutes = {
   login: () => `${basePath}/login`,
   logout: () => `${basePath}/logout`,
+  passwordRequirements: () => `${basePath}/password-requirements`,
   refreshToken: () => `${basePath}/refresh-token`,
   register: () => `${basePath}/register`,
   sendVerificationEmail: () => `${basePath}/send-verification-email`,

--- a/Okane.Client/src/features/auth/constants/authForm.ts
+++ b/Okane.Client/src/features/auth/constants/authForm.ts
@@ -1,1 +1,0 @@
-export const MIN_PASSWORD_LENGTH = 12

--- a/Okane.Client/src/features/auth/constants/copy.ts
+++ b/Okane.Client/src/features/auth/constants/copy.ts
@@ -8,6 +8,16 @@ export const AUTH_COPY = {
     EMAIL: 'Email',
     NAME: 'Name',
     PASSWORD: 'Password',
+
+    PASSWORD_REQUIREMENTS: {
+      DIGIT: '1 digit',
+      HEADING: 'Password requirements',
+      LOWERCASE_LETTER: '1 lowercase letter',
+      MATCHING_PASSWORDS: '"Confirm password" matches "Password"',
+      MIN_LENGTH: (n: number) => `${n} or more characters`,
+      NON_ALPHANUMERIC_SYMBOL: '1 non-alphanumeric symbol (e.g. @, $)',
+      UPPERCASE_LETTER: '1 uppercase letter',
+    },
   },
 
   SUCCESSFULLY_REGISTERED: {

--- a/Okane.Client/src/features/auth/constants/queryKeys.ts
+++ b/Okane.Client/src/features/auth/constants/queryKeys.ts
@@ -1,0 +1,6 @@
+const queryKeys = {
+  all: () => ['auth'],
+  passwordRequirements: () => [...queryKeys.all(), 'passwordRequirements'],
+}
+
+export const authQueryKeys = queryKeys

--- a/Okane.Client/src/features/auth/types/authForm.ts
+++ b/Okane.Client/src/features/auth/types/authForm.ts
@@ -9,9 +9,18 @@ export interface AuthFormState {
 }
 
 export type PasswordChecks = {
-  hasDigit: boolean
-  hasLowercase: boolean
-  hasUppercase: boolean
-  hasNonAlphanumeric: boolean
-  hasRequiredLength: boolean
+  insufficientLength?: boolean
+  invalidPasswordConfirm?: boolean
+  missingDigit?: boolean
+  missingLowercase?: boolean
+  missingUppercase?: boolean
+  missingNonAlphanumeric?: boolean
+}
+
+export type PasswordRequirements = {
+  minLength: number
+  requireDigit: boolean
+  requireLowercase: boolean
+  requireUppercase: boolean
+  requireNonAlphanumeric: boolean
 }

--- a/Okane.Client/src/features/auth/utils/authForm.spec.ts
+++ b/Okane.Client/src/features/auth/utils/authForm.spec.ts
@@ -1,42 +1,165 @@
 // Internal
-import { MIN_PASSWORD_LENGTH } from '@features/auth/constants/authForm'
+import { type PasswordRequirements } from '@features/auth/types/authForm'
 
-import { type PasswordChecks } from '@features/auth/types/authForm'
+import * as utils from '@features/auth/utils/authForm'
 
-import { isValidPassword } from '@features/auth/utils/authForm'
+describe('validatePassword', () => {
+  const requirements: PasswordRequirements = {
+    minLength: 12,
+    requireLowercase: true,
+    requireUppercase: true,
+    requireDigit: true,
+    requireNonAlphanumeric: true,
+  }
 
-const invalidPasswordChecks: PasswordChecks = {
-  hasDigit: false,
-  hasLowercase: false,
-  hasNonAlphanumeric: false,
-  hasRequiredLength: false,
-  hasUppercase: false,
-}
+  test('checks the length', () => {
+    const invalidPassword = 'a'.repeat(requirements.minLength - 1)
 
-const validPasswordChecks = Object.keys(invalidPasswordChecks).reduce(
-  (checks, key) => ({
-    ...checks,
-    [key]: true,
-  }),
-  {},
-)
+    let result = utils.validatePassword({
+      password: invalidPassword,
+      passwordConfirm: invalidPassword,
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.insufficientLength).toBe(true)
 
-describe('isValidPassword', () => {
-  test.each([
-    ['', false, invalidPasswordChecks],
-    [' ', false, { hasNonAlphanumeric: true }],
-    ['1', false, { hasDigit: true }],
-    ['a', false, { hasLowercase: true }],
-    ['A', false, { hasUppercase: true }],
-    ['a'.repeat(MIN_PASSWORD_LENGTH - 1), false, { hasRequiredLength: false }],
-    ['a'.repeat(MIN_PASSWORD_LENGTH), false, { hasRequiredLength: true }],
-    [` aA1${'a'.repeat(MIN_PASSWORD_LENGTH - 4)}`, true, validPasswordChecks],
-  ])(
-    `isValidPassword('%s') => { isValid: %s, passwordChecks: %o }`,
-    (password, isValid, checks) => {
-      const result = isValidPassword(password)
-      expect(result.isValid).toBe(isValid)
-      expect(result.passwordChecks).toEqual(expect.objectContaining(checks))
-    },
-  )
+    result = utils.validatePassword({
+      password: '',
+      passwordConfirm: invalidPassword,
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.insufficientLength).toBe(true)
+
+    const validPassword = 'Aa1@'.repeat(requirements.minLength)
+    result = utils.validatePassword({
+      password: validPassword,
+      passwordConfirm: invalidPassword,
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.insufficientLength).toBeUndefined()
+  })
+
+  test('checks for a lowercase letter', () => {
+    let result = utils.validatePassword({
+      password: 'A',
+      passwordConfirm: '',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.missingLowercase).toBe(true)
+
+    result = utils.validatePassword({
+      password: 'a',
+      passwordConfirm: '',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.missingLowercase).toBeUndefined()
+  })
+
+  test('checks for an uppercase letter', () => {
+    let result = utils.validatePassword({
+      password: 'a',
+      passwordConfirm: '',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.missingUppercase).toBe(true)
+    expect(result.isValid).toBe(false)
+
+    result = utils.validatePassword({
+      password: 'A',
+      passwordConfirm: '',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.missingUppercase).toBeUndefined()
+    expect(result.isValid).toBe(false)
+  })
+
+  test('checks for a digit', () => {
+    let result = utils.validatePassword({
+      password: 'a',
+      passwordConfirm: '',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.missingDigit).toBe(true)
+    expect(result.isValid).toBe(false)
+
+    result = utils.validatePassword({
+      password: '0',
+      passwordConfirm: '',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.missingDigit).toBeUndefined()
+    expect(result.isValid).toBe(false)
+  })
+
+  test('checks for a non-alphanumeric character', () => {
+    let result = utils.validatePassword({
+      password: 'a',
+      passwordConfirm: '',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.missingNonAlphanumeric).toBe(true)
+    expect(result.isValid).toBe(false)
+
+    result = utils.validatePassword({
+      password: '@',
+      passwordConfirm: '',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.missingNonAlphanumeric).toBeUndefined()
+    expect(result.isValid).toBe(false)
+  })
+
+  test('checks for a matching password confirm', () => {
+    let result = utils.validatePassword({
+      password: 'abc',
+      passwordConfirm: 'ABC',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.invalidPasswordConfirm).toBe(true)
+    expect(result.isValid).toBe(false)
+
+    result = utils.validatePassword({
+      password: '',
+      passwordConfirm: '',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.invalidPasswordConfirm).toBe(true)
+    expect(result.isValid).toBe(false)
+
+    result = utils.validatePassword({
+      password: '@',
+      passwordConfirm: '@',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result.passwordChecks.missingNonAlphanumeric).toBeUndefined()
+    expect(result.isValid).toBe(false)
+  })
+
+  test('checks multiple conditions', () => {
+    const result = utils.validatePassword({
+      password: 'a1'.repeat(requirements.minLength),
+      passwordConfirm: 'ABC',
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result).toEqual({
+      isValid: false,
+      passwordChecks: {
+        invalidPasswordConfirm: true,
+        missingUppercase: true,
+        missingNonAlphanumeric: true,
+      },
+    })
+  })
+
+  test('identifies a valid password', () => {
+    const password = 'Aa1@'.repeat(requirements.minLength)
+    const result = utils.validatePassword({
+      password,
+      passwordConfirm: password,
+      minPasswordLength: requirements.minLength,
+    })
+    expect(result).toEqual({
+      isValid: true,
+      passwordChecks: {},
+    })
+  })
 })

--- a/Okane.Client/src/features/financeRecords/components/SearchFinanceRecordsSummary.vue
+++ b/Okane.Client/src/features/financeRecords/components/SearchFinanceRecordsSummary.vue
@@ -65,7 +65,7 @@ const happenedAtCriteria = computed(() => {
     <Heading class="heading" tag="h4">{{
       FINANCES_COPY.SEARCH_FINANCE_RECORDS_MODAL.APPLIED_SEARCH_FILTERS
     }}</Heading>
-    <ul class="search-criteria">
+    <ul class="bulleted-list">
       <li>
         {{ FINANCES_COPY.PROPERTIES.TYPE }}:
         {{ searchProvider.filters.type || capitalize(SHARED_COPY.COMMON.ALL) }}
@@ -94,10 +94,5 @@ const happenedAtCriteria = computed(() => {
 
 .heading {
   margin-block: 0;
-}
-
-.search-criteria {
-  list-style-type: disc;
-  padding-left: var(--space-md);
 }
 </style>

--- a/Okane.Client/src/features/financeRecords/constants/queryKeys.ts
+++ b/Okane.Client/src/features/financeRecords/constants/queryKeys.ts
@@ -1,7 +1,7 @@
 // Internal
 import { type FinanceRecordsSearchFilters } from '@features/financeRecords/types/searchFinanceRecords'
 
-export const queryKeys = {
+const queryKeys = {
   all: () => ['financeRecords'],
   lists: () => [...queryKeys.all(), 'lists'],
   listByFilters: (args: { filters: FinanceRecordsSearchFilters }) => [

--- a/Okane.Client/src/shared/constants/form.ts
+++ b/Okane.Client/src/shared/constants/form.ts
@@ -7,6 +7,7 @@ export enum BUTTON_TYPE {
 export enum INPUT_TYPE {
   DATE = 'date',
   DATETIME_LOCAL = 'datetime-local',
+  EMAIL = 'email',
   NUMBER = 'number',
   PASSWORD = 'password',
   TEXT = 'text',

--- a/Okane.Client/src/shared/pages/LoginPage.spec.ts
+++ b/Okane.Client/src/shared/pages/LoginPage.spec.ts
@@ -14,7 +14,10 @@ import { createAppRouter, appRoutes, ROUTE_NAME } from '@shared/services/router/
 import { createTestAuthFormState } from '@tests/factories/authForm'
 
 const router = createAppRouter()
-const mountComponent = getMountComponent(LoginPage, { withPinia: true, withRouter: router })
+const mountComponent = getMountComponent(LoginPage, {
+  withQueryClient: true,
+  withRouter: router,
+})
 
 const formData = createTestAuthFormState()
 

--- a/Okane.Client/src/shared/styles/_base.scss
+++ b/Okane.Client/src/shared/styles/_base.scss
@@ -38,6 +38,11 @@ a {
   }
 }
 
+.bulleted-list {
+  list-style-type: disc;
+  padding-left: var(--space-md);
+}
+
 .visually-hidden {
   clip: rect(0 0 0 0);
   clip-path: inset(100%);


### PR DESCRIPTION
## Description
- add endpoint: `GET /api/auth/password-requirements`
- display password requirements on registration form

![69860](https://github.com/user-attachments/assets/34eab8c9-54fd-436b-a9c1-05114c2b228e)


## Linked issues
#40