### PR TITLE
Issue 86: Reset password pages

### DIFF
--- a/Okane.Client/src/features/auth/components/AuthForm.spec.ts
+++ b/Okane.Client/src/features/auth/components/AuthForm.spec.ts
@@ -6,7 +6,6 @@ import AuthForm from '@features/auth/components/AuthForm.vue'
 
 const mountComponent = getMountComponent(AuthForm)
 const props = {
-  submitButtonIsDisabled: false,
   submitButtonText: 'Hello world',
   submitError: 'Something exploded',
 }

--- a/Okane.Client/src/features/auth/components/AuthForm.vue
+++ b/Okane.Client/src/features/auth/components/AuthForm.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 export type AuthFormProps = {
-  submitButtonIsDisabled: boolean
   submitButtonText: string
 
+  submitButtonIsDisabled?: boolean
   submitError?: string
 }
 

--- a/Okane.Client/src/features/auth/components/LoginForm.vue
+++ b/Okane.Client/src/features/auth/components/LoginForm.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import { computed, ref } from 'vue'
 
 // Internal
-import AuthFormWrapper from '@features/auth/components/AuthForm.vue'
+import AuthForm from '@features/auth/components/AuthForm.vue'
 import FormInput from '@shared/components/form/FormInput.vue'
 import Heading from '@shared/components/Heading.vue'
 
@@ -38,7 +38,7 @@ async function handleSubmit() {
 
 <template>
   <Heading tag="h1">{{ AUTH_COPY.AUTH_FORM.LOGIN }}</Heading>
-  <AuthFormWrapper
+  <AuthForm
     :submit-button-is-disabled="!formIsValid"
     :submit-button-text="AUTH_COPY.AUTH_FORM.LOGIN"
     :submit-error="submitFailed ? AUTH_COPY.AUTH_FORM.LOGIN_ERROR : ''"
@@ -57,5 +57,5 @@ async function handleSubmit() {
       :type="INPUT_TYPE.PASSWORD"
       v-model="formState.password"
     />
-  </AuthFormWrapper>
+  </AuthForm>
 </template>

--- a/Okane.Client/src/features/auth/components/RegisterForm.vue
+++ b/Okane.Client/src/features/auth/components/RegisterForm.vue
@@ -3,7 +3,7 @@
 import { computed, ref } from 'vue'
 
 // Internal
-import AuthFormWrapper from '@features/auth/components/AuthForm.vue'
+import AuthForm from '@features/auth/components/AuthForm.vue'
 import FormInput from '@shared/components/form/FormInput.vue'
 import Heading from '@shared/components/Heading.vue'
 import PasswordRequirements from '@features/auth/components/PasswordRequirements.vue'
@@ -75,7 +75,7 @@ async function handleSubmit() {
 
 <template>
   <Heading tag="h1">{{ AUTH_COPY.AUTH_FORM.REGISTER }}</Heading>
-  <AuthFormWrapper
+  <AuthForm
     :submit-button-is-disabled="!formIsValid"
     :submit-button-text="AUTH_COPY.AUTH_FORM.REGISTER"
     :submit-error="hasSubmitError ? AUTH_COPY.AUTH_FORM.REGISTER_ERROR : ''"
@@ -114,5 +114,5 @@ async function handleSubmit() {
       :checks="validatePasswordResult?.passwordChecks ?? {}"
       :min-password-length="passwordRequirements.minLength"
     />
-  </AuthFormWrapper>
+  </AuthForm>
 </template>

--- a/Okane.Client/src/features/auth/components/ResetPasswordForm.spec.ts
+++ b/Okane.Client/src/features/auth/components/ResetPasswordForm.spec.ts
@@ -1,0 +1,238 @@
+// External
+import { http, HttpResponse } from 'msw'
+import { flushPromises, type VueWrapper } from '@vue/test-utils'
+
+// Internal
+import AuthForm from '@features/auth/components/AuthForm.vue'
+import PasswordRequirements from '@features/auth/components/PasswordRequirements.vue'
+import ResetPasswordForm from '@features/auth/components/ResetPasswordForm.vue'
+
+import { authAPIRoutes } from '@features/auth/constants/apiRoutes'
+import { AUTH_COPY } from '@features/auth/constants/copy'
+import { HTTP_STATUS_CODE } from '@shared/constants/http'
+import { INPUT_TYPE } from '@shared/constants/form'
+import { appRoutes, createAppRouter } from '@shared/services/router/router'
+
+import { createTestPasswordRequirements } from '@tests/factories/authForm'
+import { createTestProblemDetails } from '@tests/factories/problemDetails'
+import { getMSWURL } from '@tests/utils/url'
+import { testServer } from '@tests/msw/testServer'
+
+const requirements = createTestPasswordRequirements()
+
+function getURL(queryString: string = '') {
+  let url = appRoutes.resetPassword.buildPath()
+  if (queryString) url += `?${queryString}`
+  return url
+}
+
+async function mountComponent(
+  url: string = getURL('email=coolEmail123@okane.com&token=coolToken'),
+) {
+  const router = createAppRouter()
+  await router.push(url)
+
+  return getMountComponent(ResetPasswordForm, {
+    props: { requirements },
+    withQueryClient: true,
+    withRouter: router,
+  })()
+}
+
+const asserts = {
+  rendersAnInvalidURLError(wrapper: VueWrapper) {
+    const error = wrapper.findByText('p', AUTH_COPY.RESET_PASSWORD.INVALID_URL)
+    expect(error).toBeDefined()
+  },
+  doesNotRenderAnyErrors(wrapper: VueWrapper) {
+    let error = wrapper.findByText('p', AUTH_COPY.RESET_PASSWORD.INVALID_URL)
+    expect(error).toBeUndefined()
+
+    error = wrapper.findByText('p', AUTH_COPY.RESET_PASSWORD.RESET_ERROR)
+    expect(error).toBeUndefined()
+  },
+  doesNotRenderSuccessText(wrapper: VueWrapper) {
+    const text = wrapper.findByText('p', AUTH_COPY.RESET_PASSWORD.RESET_SUCCEEDED.SUCCESS)
+    expect(text).toBeUndefined()
+  },
+}
+
+const elements = {
+  passwordInput(wrapper: VueWrapper) {
+    return wrapper.get(`input[name="password"]`)
+  },
+  passwordConfirmInput(wrapper: VueWrapper) {
+    return wrapper.get(`input[name="passwordConfirm"]`)
+  },
+  submitButton(wrapper: VueWrapper) {
+    return wrapper.get(`button[type="submit"]`)
+  },
+}
+
+const validPassword = 'Aa1@'.repeat(requirements.minLength)
+
+test('renders a heading', async () => {
+  const wrapper = await mountComponent()
+  const heading = wrapper.findByText('h1', AUTH_COPY.RESET_PASSWORD.HEADING)
+  expect(heading).toBeDefined()
+})
+
+test('renders a password input', async () => {
+  const wrapper = await mountComponent()
+  const passwordInput = elements.passwordInput(wrapper)
+  expect(passwordInput.attributes('type')).toBe(INPUT_TYPE.PASSWORD)
+})
+
+test('renders a password confirm input', async () => {
+  const wrapper = await mountComponent()
+  const passwordConfirmInput = elements.passwordConfirmInput(wrapper)
+  expect(passwordConfirmInput.attributes('type')).toBe(INPUT_TYPE.PASSWORD)
+})
+
+test('renders password requirements', async () => {
+  const wrapper = await mountComponent()
+  const passwordRequirements = wrapper.findComponent(PasswordRequirements)
+  expect(passwordRequirements.exists()).toBe(true)
+})
+
+test('renders a submit button', async () => {
+  const wrapper = await mountComponent()
+  const submitButton = elements.submitButton(wrapper)
+  expect(submitButton.text()).toBe(AUTH_COPY.RESET_PASSWORD.SUBMIT_BUTTON)
+  expect(submitButton.attributes('disabled')).toBeDefined()
+})
+
+test('does not render success text', async () => {
+  const wrapper = await mountComponent()
+  asserts.doesNotRenderSuccessText(wrapper)
+})
+
+test('does not render any errors', async () => {
+  const wrapper = await mountComponent()
+  asserts.doesNotRenderAnyErrors(wrapper)
+})
+
+test('disables the submit button and displays the requirements until form is valid', async () => {
+  const wrapper = await mountComponent()
+  const passwordRequirements = wrapper.findComponent(PasswordRequirements)
+  const submitButton = elements.submitButton(wrapper)
+
+  const invalidPassword = 'abc'
+
+  const passwordInput = elements.passwordInput(wrapper)
+  await passwordInput.setValue(invalidPassword)
+
+  const passwordConfirmInput = elements.passwordConfirmInput(wrapper)
+  await passwordConfirmInput.setValue(invalidPassword)
+  expect(submitButton.attributes('disabled')).toBeDefined()
+  expect(passwordRequirements.exists()).toBe(true)
+
+  await passwordInput.setValue(validPassword)
+  expect(submitButton.attributes('disabled')).toBeDefined()
+  expect(passwordRequirements.exists()).toBe(true)
+
+  await passwordConfirmInput.setValue(validPassword)
+  expect(submitButton.attributes('disabled')).toBeUndefined()
+  expect(passwordRequirements.exists()).toBe(false)
+})
+
+describe('when URL is missing an email', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(async () => {
+    wrapper = await mountComponent(getURL('token=coolToken'))
+  })
+
+  test('renders an invalid URL error', () => {
+    asserts.rendersAnInvalidURLError(wrapper)
+  })
+})
+
+describe('when URL is missing a token', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(async () => {
+    wrapper = await mountComponent(getURL('email=coolEmail@okane.com'))
+  })
+
+  test('renders an invalid URL error', () => {
+    asserts.rendersAnInvalidURLError(wrapper)
+  })
+})
+
+async function populateAndSubmitForm(wrapper: VueWrapper) {
+  const passwordInput = elements.passwordInput(wrapper)
+  await passwordInput.setValue(validPassword)
+
+  const passwordConfirmInput = elements.passwordConfirmInput(wrapper)
+  await passwordConfirmInput.setValue(validPassword)
+
+  const submitButton = elements.submitButton(wrapper)
+  await submitButton.trigger('submit')
+}
+
+describe('when password reset succeeds', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(async () => {
+    const handler = http.post(getMSWURL(authAPIRoutes.resetPassword()), () =>
+      HttpResponse.json({}, { status: HTTP_STATUS_CODE.OK_200 }),
+    )
+    testServer.use(handler)
+
+    wrapper = await mountComponent()
+    await populateAndSubmitForm(wrapper)
+    await flushPromises()
+  })
+
+  test('renders success text', () => {
+    const text = wrapper.findByText('p', AUTH_COPY.RESET_PASSWORD.RESET_SUCCEEDED.SUCCESS)
+    expect(text).toBeDefined()
+  })
+
+  test('renders a link to login', () => {
+    const link = wrapper.findByText('a', AUTH_COPY.RESET_PASSWORD.RESET_SUCCEEDED.CLICK_HERE)
+    expect(link).toBeDefined()
+  })
+
+  test('does not render the form', () => {
+    const form = wrapper.findComponent(AuthForm)
+    expect(form.exists()).toBe(false)
+  })
+
+  test('does not render any errors', () => {
+    asserts.doesNotRenderAnyErrors(wrapper)
+  })
+})
+
+describe('when password reset fails', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(async () => {
+    const handler = http.post(getMSWURL(authAPIRoutes.resetPassword()), () =>
+      HttpResponse.json(createTestProblemDetails(), {
+        status: HTTP_STATUS_CODE.BAD_REQUEST_400,
+      }),
+    )
+    testServer.use(handler)
+
+    wrapper = await mountComponent()
+    await populateAndSubmitForm(wrapper)
+    await flushPromises()
+  })
+
+  test('renders a reset error', () => {
+    const error = wrapper.findByText('p', AUTH_COPY.RESET_PASSWORD.RESET_ERROR)
+    expect(error).toBeDefined()
+  })
+
+  test('does not render success text', async () => {
+    const wrapper = await mountComponent()
+    asserts.doesNotRenderSuccessText(wrapper)
+  })
+
+  test('disables the submit button', () => {
+    const submitButton = elements.submitButton(wrapper)
+    expect(submitButton.attributes('disabled')).toBeDefined()
+  })
+})

--- a/Okane.Client/src/features/auth/components/ResetPasswordForm.vue
+++ b/Okane.Client/src/features/auth/components/ResetPasswordForm.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+// External
+import { useRoute } from 'vue-router'
+import { computed, ref } from 'vue'
+
+// Internal
+import AuthForm from '@features/auth/components/AuthForm.vue'
+import FormInput from '@shared/components/form/FormInput.vue'
+import Heading from '@shared/components/Heading.vue'
+import PasswordRequirements from '@features/auth/components/PasswordRequirements.vue'
+
+import { appRoutes } from '@shared/services/router/router'
+import { AUTH_COPY } from '@features/auth/constants/copy'
+import { INPUT_TYPE } from '@shared/constants/form'
+
+import { type PasswordRequirements as PasswordRequirementsType } from '@features/auth/types/authForm'
+
+import { useResetPassword } from '@features/auth/composables/useResetPassword'
+
+import { validatePassword } from '@features/auth/utils/authForm'
+
+type Props = {
+  requirements: PasswordRequirementsType
+}
+
+const props = defineProps<Props>()
+
+const route = useRoute()
+const params = computed(() => {
+  let { email, token } = route.query
+
+  if (typeof email !== 'string') email = ''
+  if (typeof token !== 'string') token = ''
+
+  return { email, token }
+})
+
+const validURL = computed(() => params.value.email && params.value.token)
+
+const password = ref('')
+const passwordConfirm = ref('')
+const resetSucceeded = ref(false)
+
+const resetMutation = useResetPassword()
+
+const validateResult = computed(() => {
+  return validatePassword({
+    password: password.value,
+    passwordConfirm: passwordConfirm.value,
+    minPasswordLength: props.requirements.minLength,
+  })
+})
+
+function handleReset() {
+  resetMutation.mutate(
+    {
+      email: params.value.email,
+      password: password.value,
+      token: params.value.token,
+    },
+    {
+      onSuccess() {
+        resetSucceeded.value = true
+      },
+    },
+  )
+}
+</script>
+
+<template>
+  <Heading tag="h1">{{ AUTH_COPY.RESET_PASSWORD.HEADING }}</Heading>
+  <AuthForm
+    v-if="validURL && !resetSucceeded"
+    :submit-button-text="AUTH_COPY.RESET_PASSWORD.SUBMIT_BUTTON"
+    :submit-button-is-disabled="!validateResult.isValid || resetMutation.isError.value"
+    @submit="handleReset"
+  >
+    <FormInput
+      :label="AUTH_COPY.AUTH_FORM.PASSWORD"
+      name="password"
+      :type="INPUT_TYPE.PASSWORD"
+      v-model="password"
+    />
+    <FormInput
+      :label="AUTH_COPY.AUTH_FORM.CONFIRM_PASSWORD"
+      name="passwordConfirm"
+      :type="INPUT_TYPE.PASSWORD"
+      v-model="passwordConfirm"
+    />
+    <PasswordRequirements
+      v-if="!validateResult?.isValid"
+      :checks="validateResult.passwordChecks"
+      :min-password-length="props.requirements.minLength"
+    />
+  </AuthForm>
+
+  <p v-if="resetSucceeded">
+    {{ AUTH_COPY.RESET_PASSWORD.RESET_SUCCEEDED.SUCCESS }}
+    <RouterLink :to="appRoutes.login.buildPath()">{{
+      AUTH_COPY.RESET_PASSWORD.RESET_SUCCEEDED.CLICK_HERE
+    }}</RouterLink>
+  </p>
+
+  <p v-if="!validURL" class="error">{{ AUTH_COPY.RESET_PASSWORD.INVALID_URL }}</p>
+  <p v-if="resetMutation.isError.value" class="error">{{ AUTH_COPY.RESET_PASSWORD.RESET_ERROR }}</p>
+</template>
+
+<style scoped>
+.error {
+  color: var(--color-error);
+  margin-top: var(--space-sm);
+}
+</style>

--- a/Okane.Client/src/features/auth/components/SendResetPasswordEmailForm.spec.ts
+++ b/Okane.Client/src/features/auth/components/SendResetPasswordEmailForm.spec.ts
@@ -1,0 +1,142 @@
+// External
+import { http, HttpResponse } from 'msw'
+import { flushPromises, type VueWrapper } from '@vue/test-utils'
+
+import { type MockInstance } from 'vitest'
+
+// Internal
+import Heading from '@shared/components/Heading.vue'
+import SendResetPasswordEmailForm from '@features/auth/components/SendResetPasswordEmailForm.vue'
+
+import { authAPIRoutes } from '@features/auth/constants/apiRoutes'
+import { AUTH_COPY } from '@features/auth/constants/copy'
+import { HTTP_STATUS_CODE } from '@shared/constants/http'
+
+import { createTestProblemDetails } from '@tests/factories/problemDetails'
+import { getMSWURL } from '@tests/utils/url'
+import { testServer } from '@tests/msw/testServer'
+
+const mountComponent = getMountComponent(SendResetPasswordEmailForm, { withQueryClient: true })
+
+const elements = {
+  emailInput(wrapper: VueWrapper) {
+    return wrapper.get('input[type="email"]')
+  },
+  submitButton(wrapper: VueWrapper) {
+    return wrapper.get('button[type="submit"]')
+  },
+}
+
+const sharedTests = {
+  doesNotRenderAnError() {
+    test('does not render an error', () => {
+      const wrapper = mountComponent()
+      const error = wrapper.findByText('p', AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.ERROR)
+      expect(error).toBeUndefined()
+    })
+  },
+}
+
+test('renders a heading', () => {
+  const wrapper = mountComponent()
+  const heading = wrapper.getComponent(Heading)
+  expect(heading.text()).toBe(AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.RESET_PASSWORD)
+})
+
+test('renders a paragraph', () => {
+  const wrapper = mountComponent()
+  const p = wrapper.findByText('p', AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.ENTER_YOUR_EMAIL)
+  expect(p).toBeDefined()
+})
+
+test('renders an email input', () => {
+  const wrapper = mountComponent()
+  const input = elements.emailInput(wrapper)
+  expect(input.attributes('name')).toBe('email')
+})
+
+test('renders a submit button', () => {
+  const wrapper = mountComponent()
+  const button = elements.submitButton(wrapper)
+  expect(button.text()).toBe(AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.RESET_PASSWORD)
+})
+
+sharedTests.doesNotRenderAnError()
+
+describe('when submitting the form', () => {
+  async function setUp() {
+    const wrapper = mountComponent()
+
+    const email = 'sir-doggo@okane.com'
+    const emailInput = elements.emailInput(wrapper)
+    await emailInput.setValue(email)
+
+    const submitButton = elements.submitButton(wrapper)
+    await submitButton.trigger('submit')
+
+    await flushPromises()
+
+    return wrapper
+  }
+
+  describe('and email is sent successfully', () => {
+    beforeEach(() => {
+      const handler = http.post(
+        getMSWURL(authAPIRoutes.sendResetPasswordEmail()),
+        () => new HttpResponse(null, { status: HTTP_STATUS_CODE.NO_CONTENT_204 }),
+      )
+      testServer.use(handler)
+    })
+
+    test('emits a success event', async () => {
+      const wrapper = await setUp()
+      expect(wrapper.emitted('success')).toBeDefined()
+    })
+
+    test('does not log an error', async () => {
+      const spy = vi.spyOn(console, 'error')
+
+      await setUp()
+
+      expect(spy).not.toHaveBeenCalled()
+      spy.mockRestore()
+    })
+
+    sharedTests.doesNotRenderAnError()
+  })
+
+  describe('and email is not sent successfully', () => {
+    const problemDetails = createTestProblemDetails({ detail: 'Failed to send email' })
+    let consoleSpy: MockInstance
+
+    beforeEach(() => {
+      consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const handler = http.post(getMSWURL(authAPIRoutes.sendResetPasswordEmail()), () =>
+        HttpResponse.json(problemDetails, { status: HTTP_STATUS_CODE.BAD_REQUEST_400 }),
+      )
+      testServer.use(handler)
+    })
+
+    afterEach(() => {
+      consoleSpy.mockRestore()
+    })
+
+    test('does not emit a success event', async () => {
+      const wrapper = await setUp()
+      expect(wrapper.emitted('success')).toBeUndefined()
+    })
+
+    test('logs an error', async () => {
+      await setUp()
+      expect(consoleSpy).toHaveBeenCalledOnce()
+      expect(consoleSpy).toHaveBeenCalledWith(expect.any(String), problemDetails.detail)
+    })
+
+    test('renders an error', async () => {
+      const wrapper = await setUp()
+      const error = wrapper.findByText('p', AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.ERROR)
+      expect(error).toBeDefined()
+    })
+  })
+})

--- a/Okane.Client/src/features/auth/components/SendResetPasswordEmailForm.vue
+++ b/Okane.Client/src/features/auth/components/SendResetPasswordEmailForm.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+// External
+import { ref } from 'vue'
+
+// Internal
+import AuthForm from '@features/auth/components/AuthForm.vue'
+import FormInput from '@shared/components/form/FormInput.vue'
+import Heading from '@shared/components/Heading.vue'
+
+import { AUTH_COPY } from '@features/auth/constants/copy'
+import { INPUT_TYPE } from '@shared/constants/form'
+
+import { useSendResetPasswordEmail } from '@features/auth/composables/useSendResetPasswordEmail'
+
+const emit = defineEmits<{
+  (e: 'success'): void
+}>()
+
+const sendMutation = useSendResetPasswordEmail()
+const email = ref('')
+
+function handleSubmit() {
+  sendMutation.mutate(
+    { email: email.value },
+    {
+      onSuccess() {
+        emit('success')
+      },
+      onError(err) {
+        console.error('Error sending reset password email:', err)
+      },
+    },
+  )
+}
+</script>
+
+<template>
+  <Heading tag="h1">{{ AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.RESET_PASSWORD }}</Heading>
+  <p>{{ AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.ENTER_YOUR_EMAIL }}</p>
+
+  <AuthForm
+    class="auth-form"
+    :submit-button-text="AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.RESET_PASSWORD"
+    @submit="handleSubmit"
+  >
+    <div>
+      <FormInput
+        :label="AUTH_COPY.AUTH_FORM.EMAIL"
+        name="email"
+        :type="INPUT_TYPE.EMAIL"
+        v-model="email"
+      />
+
+      <p v-if="sendMutation.isError.value" class="submit-error">
+        {{ AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.ERROR }}
+      </p>
+    </div>
+  </AuthForm>
+</template>
+
+<style scoped>
+.auth-form {
+  margin-block: var(--space-md);
+}
+
+.submit-error {
+  color: var(--color-error);
+  margin-top: var(--space-xs);
+}
+</style>

--- a/Okane.Client/src/features/auth/composables/useResetPassword.spec.ts
+++ b/Okane.Client/src/features/auth/composables/useResetPassword.spec.ts
@@ -1,0 +1,40 @@
+// External
+import { defineComponent } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+// Internal
+import { authAPIRoutes } from '@features/auth/constants/apiRoutes'
+
+import { useResetPassword } from '@features/auth/composables/useResetPassword'
+
+import { apiClient } from '@shared/services/apiClient/apiClient'
+
+import { wrapInAPIResponse } from '@tests/utils/apiResponse'
+
+const spyOn = {
+  post() {
+    return vi.spyOn(apiClient, 'post').mockResolvedValue(wrapInAPIResponse('ok'))
+  },
+}
+
+const email = 'sir-doggo@okane.com'
+const password = 'cool-password'
+const token = 'cool-token'
+
+const TestComponent = defineComponent({
+  setup() {
+    const mutation = useResetPassword()
+    mutation.mutate({ email, password, token })
+  },
+  template: '<div />',
+})
+
+const mountComponent = getMountComponent(TestComponent, { withQueryClient: true })
+
+test('makes a POST request to the expected endpoint', async () => {
+  const postSpy = spyOn.post()
+
+  mountComponent()
+  await flushPromises()
+  expect(postSpy).toHaveBeenCalledWith(authAPIRoutes.resetPassword(), { email, password, token })
+})

--- a/Okane.Client/src/features/auth/composables/useResetPassword.ts
+++ b/Okane.Client/src/features/auth/composables/useResetPassword.ts
@@ -1,0 +1,13 @@
+// External
+import { useMutation } from '@tanstack/vue-query'
+
+// Internal
+import { apiClient } from '@shared/services/apiClient/apiClient'
+import { authAPIRoutes } from '@features/auth/constants/apiRoutes'
+
+export function useResetPassword() {
+  return useMutation({
+    mutationFn: (body: { email: string; password: string; token: string }) =>
+      apiClient.post(authAPIRoutes.resetPassword(), body),
+  })
+}

--- a/Okane.Client/src/features/auth/composables/useSendResetPasswordEmail.spec.ts
+++ b/Okane.Client/src/features/auth/composables/useSendResetPasswordEmail.spec.ts
@@ -1,0 +1,38 @@
+// External
+import { defineComponent } from 'vue'
+import { flushPromises } from '@vue/test-utils'
+
+// Internal
+import { authAPIRoutes } from '@features/auth/constants/apiRoutes'
+
+import { useSendResetPasswordEmail } from '@features/auth/composables/useSendResetPasswordEmail'
+
+import { apiClient } from '@shared/services/apiClient/apiClient'
+
+import { wrapInAPIResponse } from '@tests/utils/apiResponse'
+
+const spyOn = {
+  post() {
+    return vi.spyOn(apiClient, 'post').mockResolvedValue(wrapInAPIResponse('ok'))
+  },
+}
+
+const email = 'sir-doggo@okane.com'
+
+const TestComponent = defineComponent({
+  setup() {
+    const mutation = useSendResetPasswordEmail()
+    mutation.mutate({ email })
+  },
+  template: '<div />',
+})
+
+const mountComponent = getMountComponent(TestComponent, { withQueryClient: true })
+
+test('makes a POST request to the expected endpoint', async () => {
+  const postSpy = spyOn.post()
+
+  mountComponent()
+  await flushPromises()
+  expect(postSpy).toHaveBeenCalledWith(authAPIRoutes.sendResetPasswordEmail(), { email })
+})

--- a/Okane.Client/src/features/auth/composables/useSendResetPasswordEmail.ts
+++ b/Okane.Client/src/features/auth/composables/useSendResetPasswordEmail.ts
@@ -1,0 +1,13 @@
+// External
+import { useMutation } from '@tanstack/vue-query'
+
+// Internal
+import { apiClient } from '@shared/services/apiClient/apiClient'
+import { authAPIRoutes } from '@features/auth/constants/apiRoutes'
+
+export function useSendResetPasswordEmail() {
+  return useMutation({
+    mutationFn: (body: { email: string }) =>
+      apiClient.post(authAPIRoutes.sendResetPasswordEmail(), body),
+  })
+}

--- a/Okane.Client/src/features/auth/constants/apiRoutes.ts
+++ b/Okane.Client/src/features/auth/constants/apiRoutes.ts
@@ -7,6 +7,7 @@ export const authAPIRoutes = {
   passwordRequirements: () => `${basePath}/password-requirements`,
   refreshToken: () => `${basePath}/refresh-token`,
   register: () => `${basePath}/register`,
+  sendResetPasswordEmail: () => `${basePath}/send-reset-password-email`,
   sendVerificationEmail: () => `${basePath}/send-verification-email`,
   verifyEmail: () => `${basePath}/verify-email`,
 } as const

--- a/Okane.Client/src/features/auth/constants/apiRoutes.ts
+++ b/Okane.Client/src/features/auth/constants/apiRoutes.ts
@@ -7,6 +7,7 @@ export const authAPIRoutes = {
   passwordRequirements: () => `${basePath}/password-requirements`,
   refreshToken: () => `${basePath}/refresh-token`,
   register: () => `${basePath}/register`,
+  resetPassword: () => `${basePath}/reset-password`,
   sendResetPasswordEmail: () => `${basePath}/send-reset-password-email`,
   sendVerificationEmail: () => `${basePath}/send-verification-email`,
   verifyEmail: () => `${basePath}/verify-email`,

--- a/Okane.Client/src/features/auth/constants/copy.ts
+++ b/Okane.Client/src/features/auth/constants/copy.ts
@@ -1,10 +1,10 @@
 export const AUTH_COPY = {
+  FORGOT_PASSWORD: 'I forgot my password.',
   LOGOUT: 'Logout',
 
   AUTH_FORM: {
     CONFIRM_PASSWORD: 'Confirm password',
     EMAIL: 'Email',
-
     LOGIN: 'Login',
     LOGIN_ERROR: 'Invalid email or password',
     NAME: 'Name',
@@ -20,6 +20,16 @@ export const AUTH_COPY = {
       MIN_LENGTH: (n: number) => `${n} or more characters`,
       NON_ALPHANUMERIC_SYMBOL: '1 non-alphanumeric symbol (e.g. @, $)',
       UPPERCASE_LETTER: '1 uppercase letter',
+    },
+  },
+
+  SEND_RESET_PASSWORD_EMAIL: {
+    ERROR: 'Error sending reset password email. Please try again later.',
+    ENTER_YOUR_EMAIL: 'Enter your email to reset your password.',
+    RESET_PASSWORD: 'Reset Password',
+    SUCCESS: {
+      HEADING: 'Sent email!',
+      BODY: 'In a few minutes, you should receive an email to reset your password.',
     },
   },
 

--- a/Okane.Client/src/features/auth/constants/copy.ts
+++ b/Okane.Client/src/features/auth/constants/copy.ts
@@ -23,6 +23,18 @@ export const AUTH_COPY = {
     },
   },
 
+  RESET_PASSWORD: {
+    HEADING: 'Reset Password',
+    INVALID_URL: 'Invalid URL. Please request a new reset password email and try again.',
+    RESET_ERROR:
+      'Error resetting password. Please request a new reset password email and try again.',
+    RESET_SUCCEEDED: {
+      SUCCESS: 'Successfully reset password!',
+      CLICK_HERE: 'Click here to login.',
+    },
+    SUBMIT_BUTTON: 'Reset Password',
+  },
+
   SEND_RESET_PASSWORD_EMAIL: {
     ERROR: 'Error sending reset password email. Please try again later.',
     ENTER_YOUR_EMAIL: 'Enter your email to reset your password.',

--- a/Okane.Client/src/shared/components/NavBar.spec.ts
+++ b/Okane.Client/src/shared/components/NavBar.spec.ts
@@ -6,7 +6,6 @@ import NavBar from '@shared/components/NavBar.vue'
 
 import { authHandlers } from '@tests/msw/handlers/auth'
 import { AUTH_COPY } from '@features/auth/constants/copy'
-import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 import { appRoutes } from '@shared/services/router/router'
 
 import { useAuthStore } from '@features/auth/composables/useAuthStore'
@@ -46,11 +45,7 @@ describe('when authenticated', () => {
     const wrapper = mountComponent()
 
     const allLinks = wrapper.findAll('a')
-    expect(allLinks).toHaveLength(2)
-
-    const financesURL = appRoutes.finances.buildPath()
-    const financesLink = wrapper.get(`a[href="${financesURL}"]`)
-    expect(financesLink.text()).toBe(FINANCES_COPY.FINANCES)
+    expect(allLinks).toHaveLength(1)
 
     const logoutLink = wrapper.get(`a[href="/#"]`)
     expect(logoutLink.text()).toBe(AUTH_COPY.LOGOUT)

--- a/Okane.Client/src/shared/components/NavBar.vue
+++ b/Okane.Client/src/shared/components/NavBar.vue
@@ -15,7 +15,6 @@ const authStore = useAuthStore()
 <template>
   <nav class="nav">
     <template v-if="authStore.isLoggedIn">
-      <RouterLink :to="{ name: ROUTE_NAME.FINANCES }">{{ FINANCES_COPY.FINANCES }}</RouterLink>
       <RouterLink to="#" @click="authStore.logout">{{ AUTH_COPY.LOGOUT }}</RouterLink>
     </template>
     <template v-else>

--- a/Okane.Client/src/shared/pages/LoginPage.spec.ts
+++ b/Okane.Client/src/shared/pages/LoginPage.spec.ts
@@ -2,6 +2,9 @@
 import LoginPage from '@shared/pages/LoginPage.vue'
 import LoginForm from '@features/auth/components/LoginForm.vue'
 
+import { appRoutes } from '@shared/services/router/router'
+import { AUTH_COPY } from '@features/auth/constants/copy'
+
 const mountComponent = getMountComponent(LoginPage, {
   withQueryClient: true,
   withRouter: true,
@@ -10,4 +13,10 @@ const mountComponent = getMountComponent(LoginPage, {
 test('renders a LoginForm', () => {
   const wrapper = mountComponent()
   expect(wrapper.findComponent(LoginForm).exists()).toBe(true)
+})
+
+test('renders a "forgot password" link', () => {
+  const wrapper = mountComponent()
+  const link = wrapper.findByText('a', AUTH_COPY.FORGOT_PASSWORD)
+  expect(link.attributes('href')).toBe(appRoutes.sendResetPasswordEmail.buildPath())
 })

--- a/Okane.Client/src/shared/pages/LoginPage.vue
+++ b/Okane.Client/src/shared/pages/LoginPage.vue
@@ -1,11 +1,27 @@
 <script setup lang="ts">
+// External
+import { RouterLink } from 'vue-router'
+
 // Internal
 import LoginForm from '@features/auth/components/LoginForm.vue'
 import PageLayout from '@shared/layouts/PageLayout.vue'
+
+import { AUTH_COPY } from '@features/auth/constants/copy'
+import { ROUTE_NAME } from '@shared/services/router/router'
 </script>
 
 <template>
   <PageLayout>
     <LoginForm />
+    <RouterLink class="forgot-password" :to="{ name: ROUTE_NAME.SEND_RESET_PASSWORD_EMAIL }">{{
+      AUTH_COPY.FORGOT_PASSWORD
+    }}</RouterLink>
   </PageLayout>
 </template>
+
+<style scoped>
+.forgot-password {
+  display: inline-block;
+  margin-top: var(--space-md);
+}
+</style>

--- a/Okane.Client/src/shared/pages/ResetPasswordPage.spec.ts
+++ b/Okane.Client/src/shared/pages/ResetPasswordPage.spec.ts
@@ -1,0 +1,41 @@
+// External
+import { flushPromises, VueWrapper } from '@vue/test-utils'
+
+// Internal
+import ResetPasswordForm from '@features/auth/components/ResetPasswordForm.vue'
+import ResetPasswordPage from '@shared/pages/ResetPasswordPage.vue'
+
+import { authHandlers } from '@tests/msw/handlers/auth'
+import { testServer } from '@tests/msw/testServer'
+
+const mountComponent = getMountComponent(ResetPasswordPage, {
+  withQueryClient: true,
+  withRouter: true,
+})
+
+async function setUpWithPasswordRequirements({ shouldFlushPromises = true } = {}) {
+  testServer.use(authHandlers.getPasswordRequirementsSuccess())
+
+  const wrapper = mountComponent()
+
+  if (shouldFlushPromises) await flushPromises()
+
+  return wrapper
+}
+
+test('renders a ResetPasswordForm', async () => {
+  const wrapper = await setUpWithPasswordRequirements()
+  expect(wrapper.findComponent(ResetPasswordForm).exists()).toBe(true)
+})
+
+describe('while fetching password requirements', () => {
+  let wrapper: VueWrapper
+
+  beforeEach(async () => {
+    wrapper = await setUpWithPasswordRequirements({ shouldFlushPromises: false })
+  })
+
+  test('does not render a RegisterForm', () => {
+    expect(wrapper.findComponent(ResetPasswordForm).exists()).toBe(false)
+  })
+})

--- a/Okane.Client/src/shared/pages/ResetPasswordPage.vue
+++ b/Okane.Client/src/shared/pages/ResetPasswordPage.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+// Internal
+import PageLayout from '@shared/layouts/PageLayout.vue'
+import ResetPasswordForm from '@features/auth/components/ResetPasswordForm.vue'
+
+import { useQueryPasswordRequirements } from '@features/auth/composables/useQueryPasswordRequirements'
+
+const { data: requirements } = useQueryPasswordRequirements()
+</script>
+
+<template>
+  <PageLayout>
+    <ResetPasswordForm v-if="requirements" :requirements="requirements" />
+  </PageLayout>
+</template>

--- a/Okane.Client/src/shared/pages/SendResetPasswordEmailPage.spec.ts
+++ b/Okane.Client/src/shared/pages/SendResetPasswordEmailPage.spec.ts
@@ -1,0 +1,47 @@
+// External
+import { type VueWrapper } from '@vue/test-utils'
+
+// Internal
+import Heading from '@shared/components/Heading.vue'
+import SendResetPasswordEmailForm from '@features/auth/components/SendResetPasswordEmailForm.vue'
+import SendResetPasswordEmailPage from '@shared/pages/SendResetPasswordEmailPage.vue'
+
+import { AUTH_COPY } from '@features/auth/constants/copy'
+
+const mountComponent = getMountComponent(SendResetPasswordEmailPage, {
+  global: {
+    stubs: {
+      SendResetPasswordEmailForm: true,
+    },
+  },
+})
+
+test('renders a SendResetPasswordEmailForm', () => {
+  const wrapper = mountComponent()
+  expect(wrapper.findComponent(SendResetPasswordEmailForm).exists()).toBe(true)
+})
+
+test('does not render the success text', () => {
+  const wrapper = mountComponent()
+  expect(wrapper.findComponent(Heading).exists()).toBe(false)
+  expect(wrapper.findByText('p', AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.SUCCESS.BODY)).toBeUndefined()
+})
+
+describe('when the email is successfully sent', () => {
+  let wrapper: VueWrapper
+  beforeEach(() => {
+    wrapper = mountComponent()
+
+    const form = wrapper.findComponent(SendResetPasswordEmailForm)
+    form.vm.$emit('success')
+  })
+
+  test('does not render a SendResetPasswordEmailForm', () => {
+    expect(wrapper.findComponent(SendResetPasswordEmailForm).exists()).toBe(false)
+  })
+
+  test('renders the success text', () => {
+    expect(wrapper.findComponent(Heading).exists()).toBe(true)
+    expect(wrapper.findByText('p', AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.SUCCESS.BODY)).toBeDefined()
+  })
+})

--- a/Okane.Client/src/shared/pages/SendResetPasswordEmailPage.vue
+++ b/Okane.Client/src/shared/pages/SendResetPasswordEmailPage.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+// External
+import { ref } from 'vue'
+
+// Internal
+import Heading from '@shared/components/Heading.vue'
+import PageLayout from '@shared/layouts/PageLayout.vue'
+import SendResetPasswordEmailForm from '@features/auth/components/SendResetPasswordEmailForm.vue'
+
+import { AUTH_COPY } from '@features/auth/constants/copy'
+
+const sendSucceeded = ref(false)
+</script>
+
+<template>
+  <PageLayout>
+    <SendResetPasswordEmailForm v-if="!sendSucceeded" @success="sendSucceeded = true" />
+
+    <template v-else>
+      <Heading tag="h1">{{ AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.SUCCESS.HEADING }}</Heading>
+      <p>{{ AUTH_COPY.SEND_RESET_PASSWORD_EMAIL.SUCCESS.BODY }}</p>
+    </template>
+  </PageLayout>
+</template>

--- a/Okane.Client/src/shared/services/router/router.ts
+++ b/Okane.Client/src/shared/services/router/router.ts
@@ -5,6 +5,7 @@ import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 import FinancesPage from '@shared/pages/FinancesPage.vue'
 import LoginPage from '@shared/pages/LoginPage.vue'
 import RegisterPage from '@shared/pages/RegisterPage.vue'
+import SendResetPasswordEmail from '@shared/pages/SendResetPasswordEmailPage.vue'
 import VerifyEmailPage from '@shared/pages/VerifyEmailPage.vue'
 
 import { useAuthStore } from '@features/auth/composables/useAuthStore'
@@ -15,6 +16,7 @@ export enum ROUTE_NAME {
   FINANCES = 'finances',
   LOGIN = 'login',
   REGISTER = 'register',
+  SEND_RESET_PASSWORD_EMAIL = 'sendResetPasswordEmail',
   VERIFY_EMAIL = 'verifyEmail',
 }
 
@@ -40,6 +42,13 @@ export const appRoutes: Record<ROUTE_NAME, Route> = {
     buildPath: () => '/register',
     name: ROUTE_NAME.REGISTER,
     component: RegisterPage,
+    meta: { isPublic: true, isPublicOnly: true },
+  },
+  [ROUTE_NAME.SEND_RESET_PASSWORD_EMAIL]: {
+    path: '/send-reset-password-email',
+    buildPath: () => '/send-reset-password-email',
+    name: ROUTE_NAME.SEND_RESET_PASSWORD_EMAIL,
+    component: SendResetPasswordEmail,
     meta: { isPublic: true, isPublicOnly: true },
   },
   [ROUTE_NAME.VERIFY_EMAIL]: {

--- a/Okane.Client/src/shared/services/router/router.ts
+++ b/Okane.Client/src/shared/services/router/router.ts
@@ -5,6 +5,7 @@ import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router'
 import FinancesPage from '@shared/pages/FinancesPage.vue'
 import LoginPage from '@shared/pages/LoginPage.vue'
 import RegisterPage from '@shared/pages/RegisterPage.vue'
+import ResetPasswordPage from '@shared/pages/ResetPasswordPage.vue'
 import SendResetPasswordEmail from '@shared/pages/SendResetPasswordEmailPage.vue'
 import VerifyEmailPage from '@shared/pages/VerifyEmailPage.vue'
 
@@ -16,6 +17,7 @@ export enum ROUTE_NAME {
   FINANCES = 'finances',
   LOGIN = 'login',
   REGISTER = 'register',
+  RESET_PASSWORD = 'resetPassword',
   SEND_RESET_PASSWORD_EMAIL = 'sendResetPasswordEmail',
   VERIFY_EMAIL = 'verifyEmail',
 }
@@ -42,6 +44,13 @@ export const appRoutes: Record<ROUTE_NAME, Route> = {
     buildPath: () => '/register',
     name: ROUTE_NAME.REGISTER,
     component: RegisterPage,
+    meta: { isPublic: true, isPublicOnly: true },
+  },
+  [ROUTE_NAME.RESET_PASSWORD]: {
+    path: '/reset-password',
+    buildPath: () => '/reset-password',
+    name: ROUTE_NAME.RESET_PASSWORD,
+    component: ResetPasswordPage,
     meta: { isPublic: true, isPublicOnly: true },
   },
   [ROUTE_NAME.SEND_RESET_PASSWORD_EMAIL]: {


### PR DESCRIPTION
## Description
- add page to send reset password email
- add page to reset password

### Other
- remove `/finances` link in navbar

![Send reset password email page](https://github.com/user-attachments/assets/b5b1db98-cfab-4929-a13c-f6f965e3c196)
![Reset password page](https://github.com/user-attachments/assets/d94b5ac2-ac64-4496-a0b8-3d3c95c13afd)


## Linked issues
#86