### PR TITLE
Issue 41: Toaster

### DIFF
--- a/Okane.Client/index.html
+++ b/Okane.Client/index.html
@@ -8,6 +8,8 @@
   </head>
   <body>
     <div id="app"></div>
+    <div id="modal"></div>
+    <div id="toaster"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/Okane.Client/src/App.spec.ts
+++ b/Okane.Client/src/App.spec.ts
@@ -1,0 +1,27 @@
+// Internal
+import App from './App.vue'
+import NavBar from '@shared/components/NavBar.vue'
+import Toaster from '@shared/components/toast/Toaster.vue'
+
+const mountComponent = getMountComponent(App, {
+  global: {
+    stubs: {
+      NavBar: true,
+      RouterView: true,
+      Teleport: true,
+      Toaster: true,
+    },
+  },
+  withRouter: true,
+  withQueryClient: true,
+})
+
+test('renders a nav bar', () => {
+  const wrapper = mountComponent()
+  expect(wrapper.findComponent(NavBar).exists()).toBe(true)
+})
+
+test('renders a toast', () => {
+  const wrapper = mountComponent()
+  expect(wrapper.findComponent(Toaster).exists()).toBe(true)
+})

--- a/Okane.Client/src/App.vue
+++ b/Okane.Client/src/App.vue
@@ -5,6 +5,7 @@ import { VueQueryDevtools } from '@tanstack/vue-query-devtools'
 
 // Internal
 import NavBar from '@shared/components/NavBar.vue'
+import Toaster from '@shared/components/toast/Toaster.vue'
 </script>
 
 <template>
@@ -12,5 +13,6 @@ import NavBar from '@shared/components/NavBar.vue'
     <NavBar />
   </header>
   <RouterView />
+  <Toaster />
   <VueQueryDevtools buttonPosition="bottom-left" />
 </template>

--- a/Okane.Client/src/__tests__/factories/toaster.ts
+++ b/Okane.Client/src/__tests__/factories/toaster.ts
@@ -1,0 +1,13 @@
+// Internal
+import { baseTestObjectFactory, type TestObjectFactoryFunction } from '@tests/factories/base'
+import { type Toast } from '@shared/types/toaster'
+
+const defaultToast: Toast = {
+  id: 1,
+  text: 'Hello world',
+  type: 'success',
+}
+
+export const createTestToast: TestObjectFactoryFunction<Toast> = (overrides, options) => {
+  return baseTestObjectFactory(defaultToast, overrides, options)
+}

--- a/Okane.Client/src/__tests__/utils/commonAsserts.ts
+++ b/Okane.Client/src/__tests__/utils/commonAsserts.ts
@@ -5,13 +5,21 @@ import { type DOMWrapper, type VueWrapper } from '@vue/test-utils'
 import ModalHeading from '@shared/components/modal/ModalHeading.vue'
 
 import { ARIA_ATTRIBUTES } from '@shared/constants/aria'
+import { TEST_IDS } from '@shared/constants/testIds'
 
 import { type SelectOption } from '@shared/components/form/FormSelect.vue'
 
 export const commonAsserts = {
-  rendersAnAccessibleDialog(args: { dialog: Omit<DOMWrapper<Element>, 'exists'> }) {
-    const dialogLabelledBy = args.dialog.attributes(ARIA_ATTRIBUTES.LABELLED_BY)
-    const heading = args.dialog.getComponent(ModalHeading)
+  rendersAnAccessibleModal({
+    wrapper,
+    selector = `[data-testid="${TEST_IDS.MODAL}"]`,
+  }: {
+    wrapper: VueWrapper
+    selector?: string
+  }) {
+    const modal = wrapper.get(selector)
+    const dialogLabelledBy = modal.attributes(ARIA_ATTRIBUTES.LABELLED_BY)
+    const heading = modal.getComponent(ModalHeading)
     expect(heading.attributes('id')).toBe(dialogLabelledBy)
   },
   rendersExpectedSelectOptions(args: {

--- a/Okane.Client/src/features/auth/constants/copy.ts
+++ b/Okane.Client/src/features/auth/constants/copy.ts
@@ -63,7 +63,7 @@ export const AUTH_COPY = {
     ENTER_YOUR_EMAIL: 'Enter your email to reset your password.',
     RESET_PASSWORD: 'Reset Password',
     SUCCESS: {
-      HEADING: 'Sent email!',
+      HEADING: 'Sent password reset email!',
       BODY: 'In a few minutes, you should receive an email to reset your password.',
     },
   },

--- a/Okane.Client/src/features/financeRecords/components/CreateFinanceRecordModal.vue
+++ b/Okane.Client/src/features/financeRecords/components/CreateFinanceRecordModal.vue
@@ -10,6 +10,7 @@ import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 import { type SaveFinanceRecordFormState } from '@features/financeRecords/types/saveFinanceRecord'
 
 import { useCreateFinanceRecord } from '@features/financeRecords/composables/useCreateFinanceRecord'
+import { useToastStore } from '@shared/composables/useToastStore'
 
 import {
   SAVE_FINANCE_RECORD_SYMBOL,
@@ -28,6 +29,8 @@ const saveProvider = inject(SAVE_FINANCE_RECORD_SYMBOL) as SaveFinanceRecordProv
 const formState = ref<SaveFinanceRecordFormState>(getInitialSaveFinanceRecordFormState())
 const initialFormErrors = getInitialFormErrors(formState.value)
 const formErrors = ref({ ...initialFormErrors })
+
+const { createToast } = useToastStore()
 
 function handleChange(updates: Partial<SaveFinanceRecordFormState>) {
   formState.value = {
@@ -52,6 +55,8 @@ function handleSubmit() {
         amount: 0,
         description: '',
       }
+
+      createToast(FINANCES_COPY.SAVE_FINANCE_RECORD_MODAL.CREATE_SUCCESS_TOAST)
     },
     onError(err) {
       if (isObjectType(err)) {

--- a/Okane.Client/src/features/financeRecords/components/DeleteFinanceRecordModal.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/DeleteFinanceRecordModal.spec.ts
@@ -73,10 +73,10 @@ test('renders the modal heading', () => {
   expect(heading.text()).toBe(FINANCES_COPY.DELETE_FINANCE_RECORD_MODAL.DELETE_FINANCE_RECORD)
 })
 
-test('renders an accessible dialog', () => {
+test('renders an accessible modal', () => {
   const deleteProvider = helpers.getDeleteProviderWithIdSet()
   const wrapper = mountComponentWithDeleteProvider(deleteProvider)
-  commonAsserts.rendersAnAccessibleDialog({ dialog: wrapper.get('dialog') })
+  commonAsserts.rendersAnAccessibleModal({ wrapper })
 })
 
 test('renders the confirmation text', () => {

--- a/Okane.Client/src/features/financeRecords/components/EditFinanceRecordModal.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/EditFinanceRecordModal.spec.ts
@@ -11,6 +11,8 @@ import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 
 import { type SaveFinanceRecordFormState } from '@features/financeRecords/types/saveFinanceRecord'
 
+import { useToastStore } from '@shared/composables/useToastStore'
+
 import {
   mapFinanceRecord,
   mapSaveFinanceRecordFormState,
@@ -32,6 +34,7 @@ import { createTestAPIFormErrors } from '@tests/factories/formErrors'
 import { createTestFinanceRecord } from '@tests/factories/financeRecord'
 import { createTestProblemDetails } from '@tests/factories/problemDetails'
 import { financeUserTagHandlers } from '@tests/msw/handlers/financeUserTag'
+import { useMockedStore } from '@tests/composables/useMockedStore'
 import { testServer } from '@tests/msw/testServer'
 import { wrapInAPIResponse } from '@tests/utils/apiResponse'
 
@@ -150,6 +153,25 @@ describe('with a successful request to edit a finance record', () => {
       financeRecord,
     )
 
+    patchSpy.mockRestore()
+  })
+
+  test('creates a toast', async () => {
+    const toastStore = useMockedStore(useToastStore)
+    const createToastSpy = vi.spyOn(toastStore, 'createToast')
+    const patchSpy = vi.spyOn(apiClient, 'patch').mockResolvedValue(wrapInAPIResponse(null))
+    const saveProvider = helpers.getEditingSaveProvider()
+    const wrapper = mountWithProviders({ saveProvider })
+
+    helpers.setFormState(wrapper, updates)
+    expect(createToastSpy).not.toHaveBeenCalled()
+    await helpers.submitForm(wrapper)
+    expect(createToastSpy).toHaveBeenCalledOnce()
+    expect(createToastSpy).toHaveBeenCalledWith(
+      FINANCES_COPY.SAVE_FINANCE_RECORD_MODAL.EDIT_SUCCESS_TOAST,
+    )
+
+    createToastSpy.mockRestore()
     patchSpy.mockRestore()
   })
 

--- a/Okane.Client/src/features/financeRecords/components/EditFinanceRecordModal.vue
+++ b/Okane.Client/src/features/financeRecords/components/EditFinanceRecordModal.vue
@@ -7,9 +7,10 @@ import SaveFinanceRecordModal from '@features/financeRecords/components/SaveFina
 
 import { FINANCES_COPY } from '@features/financeRecords/constants/copy'
 
-import type { SaveFinanceRecordFormState } from '@features/financeRecords/types/saveFinanceRecord'
+import { type SaveFinanceRecordFormState } from '@features/financeRecords/types/saveFinanceRecord'
 
 import { useEditFinanceRecord } from '@features/financeRecords/composables/useEditFinanceRecord'
+import { useToastStore } from '@shared/composables/useToastStore'
 
 import {
   SAVE_FINANCE_RECORD_SYMBOL,
@@ -39,6 +40,8 @@ const initialFormState = computed(() => {
 const formState = ref<SaveFinanceRecordFormState>(getInitialSaveFinanceRecordFormState())
 const initialFormErrors = getInitialFormErrors(formState.value)
 const formErrors = ref({ ...initialFormErrors })
+
+const { createToast } = useToastStore()
 
 // When the editing finance record changes, reset the form state.
 watchEffect(() => {
@@ -72,6 +75,7 @@ function handleSubmit() {
     { id, request: mapSaveFinanceRecordFormState.to.editFinanceRecordRequest(changes) },
     {
       onSuccess() {
+        createToast(FINANCES_COPY.SAVE_FINANCE_RECORD_MODAL.EDIT_SUCCESS_TOAST)
         handleClose()
       },
       onError(err) {

--- a/Okane.Client/src/features/financeRecords/components/SaveFinanceRecordModal.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/SaveFinanceRecordModal.spec.ts
@@ -56,7 +56,7 @@ test('renders the modal heading', () => {
 
 test('renders an accessible dialog', () => {
   const wrapper = mountComponent()
-  commonAsserts.rendersAnAccessibleDialog({ dialog: wrapper.get('dialog') })
+  commonAsserts.rendersAnAccessibleModal({ wrapper })
 })
 
 test('renders the form inputs', () => {

--- a/Okane.Client/src/features/financeRecords/components/SearchFinanceRecordsModal.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/SearchFinanceRecordsModal.spec.ts
@@ -49,9 +49,9 @@ test('renders the modal heading', () => {
   expect(modalHeading.text()).toBe(FINANCES_COPY.SEARCH_FINANCE_RECORDS_MODAL.EDIT_SEARCH_FILTERS)
 })
 
-test('renders an accessible dialog', () => {
+test('renders an accessible modal', () => {
   const wrapper = mountWithProviders()
-  commonAsserts.rendersAnAccessibleDialog({ dialog: wrapper.get('dialog') })
+  commonAsserts.rendersAnAccessibleModal({ wrapper })
 })
 
 test('renders a form to edit finance records search filters', () => {

--- a/Okane.Client/src/features/financeRecords/components/SearchFinanceRecordsSection.spec.ts
+++ b/Okane.Client/src/features/financeRecords/components/SearchFinanceRecordsSection.spec.ts
@@ -30,6 +30,9 @@ function mountComponent(
       provide: {
         [SEARCH_FINANCE_RECORDS_SYMBOL]: args.searchProvider ?? useSearchFinanceRecordsProvider(),
       },
+      stubs: {
+        teleport: true,
+      },
     },
     withQueryClient: true,
     withRouter: args.router ?? true,

--- a/Okane.Client/src/features/financeRecords/constants/copy.ts
+++ b/Okane.Client/src/features/financeRecords/constants/copy.ts
@@ -26,7 +26,9 @@ export const FINANCES_COPY = {
 
   SAVE_FINANCE_RECORD_MODAL: {
     CREATE_FINANCE_RECORD: 'Create Finance Record',
+    CREATE_SUCCESS_TOAST: 'Successfully created finance record.',
     EDIT_FINANCE_RECORD: 'Edit Finance Record',
+    EDIT_SUCCESS_TOAST: 'Successfully saved finance record.',
     SHOW_MODAL: 'Show save finance record modal.',
   },
 

--- a/Okane.Client/src/shared/components/InfiniteScroller.spec.ts
+++ b/Okane.Client/src/shared/components/InfiniteScroller.spec.ts
@@ -1,6 +1,6 @@
 // External
 import { flushPromises } from '@vue/test-utils'
-import { computed, defineComponent, watchEffect } from 'vue'
+import { computed, defineComponent } from 'vue'
 import { http, HttpResponse } from 'msw'
 
 // Internal
@@ -46,10 +46,6 @@ function getTestComponent(errorTemplate?: string) {
     setup() {
       const queryResult = useInfiniteQueryFinanceRecords()
       const items = computed(() => flattenPages(queryResult?.data?.value?.pages ?? []))
-
-      watchEffect(() => {
-        console.log('items', items.value)
-      })
 
       return { queryResult, items }
     },

--- a/Okane.Client/src/shared/components/ToggleMenu.vue
+++ b/Okane.Client/src/shared/components/ToggleMenu.vue
@@ -92,7 +92,7 @@ function handleClick(callback: MenuAction['onClick']) {
   overflow: hidden;
   position: absolute;
   transform: translate(-0.5rem, 3.25rem);
-  z-index: 1;
+  z-index: var(--z-index-toggle-menu);
 }
 
 .menu-item {

--- a/Okane.Client/src/shared/components/modal/Modal.vue
+++ b/Okane.Client/src/shared/components/modal/Modal.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 // External
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { useTemplateRef, watch } from 'vue'
+import { onClickOutside } from '@vueuse/core'
+import { useTemplateRef } from 'vue'
 
 // Internal
 import { SHARED_COPY } from '@shared/constants/copy'
+import { TEST_IDS } from '@shared/constants/testIds'
 
 // Internal
 type Props = {
@@ -18,56 +20,58 @@ const emit = defineEmits<{
   (event: 'close'): void
 }>()
 
+const backdropRef = useTemplateRef<HTMLDivElement>('backdropRef')
 const dialogRef = useTemplateRef<HTMLDialogElement>('dialogRef')
 
 function emitModalClose() {
   emit('close')
 }
 
-function handleOutsideClick(event: Event) {
-  const target = event.target as HTMLDialogElement
-  if (target.nodeName === 'DIALOG') {
-    emitModalClose()
-  }
-}
-
-watch(
-  () => props.isShowing,
-  () => {
-    if (props.isShowing) {
-      // "?." is needed because jsdom doesn't support dialogs. Dialog methods won't be present when
-      // running tests.
-      dialogRef.value?.showModal?.()
-    } else {
-      dialogRef.value?.close?.()
-    }
-  },
-)
+onClickOutside(dialogRef, (event) => {
+  if (event.target === backdropRef.value) emitModalClose()
+})
 </script>
 
 <template>
-  <Teleport to="body">
-    <dialog
-      aria-modal="true"
-      :aria-labelledby="props.modalHeadingId"
-      class="modal"
-      :data-disable-document-scroll="props.isShowing"
-      ref="dialogRef"
-      v-bind="$attrs"
-      @close="emitModalClose"
-      @mousedown="handleOutsideClick"
+  <Teleport to="#modal">
+    <div
+      v-if="props.isShowing"
+      class="backdrop"
+      ref="backdropRef"
+      :data-testid="TEST_IDS.MODAL_BACKDROP"
     >
-      <div class="modal-content" v-if="props.isShowing">
-        <button class="close-button" @click="emitModalClose">
-          <FontAwesomeIcon icon="fa-solid fa-xmark" :title="SHARED_COPY.MODAL.CLOSE_MODAL" />
-        </button>
-        <slot />
+      <div
+        aria-modal="true"
+        :aria-labelledby="props.modalHeadingId"
+        class="modal"
+        :data-disable-document-scroll="props.isShowing"
+        ref="dialogRef"
+        :data-testid="TEST_IDS.MODAL"
+        v-bind="$attrs"
+        @close="emitModalClose"
+      >
+        <div class="modal-content">
+          <button class="close-button" @click="emitModalClose">
+            <FontAwesomeIcon icon="fa-solid fa-xmark" :title="SHARED_COPY.MODAL.CLOSE_MODAL" />
+          </button>
+          <slot />
+        </div>
       </div>
-    </dialog>
+    </div>
   </Teleport>
 </template>
 
 <style scoped lang="scss">
+.backdrop {
+  background-color: rgba(0, 0, 0, 35%);
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  top: 0;
+  right: 0;
+  z-index: var(--z-index-modal);
+}
+
 .close-button {
   border: none;
   border-radius: 100%;
@@ -81,8 +85,10 @@ watch(
 }
 
 .modal {
+  background-color: var(--color-gray-50);
   border: none;
   border-radius: 0.5rem;
+  color: var(--color-gray-900);
   padding: 0;
 
   height: 100%;
@@ -91,17 +97,15 @@ watch(
   max-width: 100%;
 
   @include respond(sm) {
+    position: absolute;
+    left: 0;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    margin: auto;
     height: max-content;
     max-width: pxToRem(400);
-
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
   }
-}
-
-.modal::backdrop {
-  background: rgba(0, 0, 0, 50%);
 }
 
 .modal-content {

--- a/Okane.Client/src/shared/components/toast/Toast.spec.ts
+++ b/Okane.Client/src/shared/components/toast/Toast.spec.ts
@@ -1,0 +1,108 @@
+// Internal
+import Toast from '@shared/components/toast/Toast.vue'
+
+import { HTML_ROLE } from '@shared/constants/html'
+import { SHARED_COPY } from '@shared/constants/copy'
+import { TOAST_HIDE_AFTER_MS } from '@shared/constants/toast'
+
+import { useToastStore } from '@shared/composables/useToastStore'
+
+import { createTestToast } from '@tests/factories/toaster'
+import { useMockedStore } from '@tests/composables/useMockedStore'
+
+const mountComponent = getMountComponent(Toast, {
+  withPinia: true,
+})
+
+const spyOn = {
+  removeToast() {
+    const toastStore = useMockedStore(useToastStore)
+    return vi.spyOn(toastStore, 'removeToast')
+  },
+}
+
+const defaultToast = createTestToast()
+
+test('renders the toast text', () => {
+  const wrapper = mountComponent({
+    props: {
+      toast: defaultToast,
+    },
+  })
+  expect(wrapper.findByText('p', defaultToast.text)).toBeDefined()
+})
+
+test('applies attributes for a success toast', () => {
+  const toast = createTestToast({ type: 'success' })
+  const wrapper = mountComponent({ props: { toast } })
+  const element = wrapper.get(`[role=${HTML_ROLE.STATUS}]`)
+  expect(element.attributes('aria-atomic')).toBe('true')
+})
+
+test('applies attributes for an error toast', () => {
+  const toast = createTestToast({ type: 'error' })
+  const wrapper = mountComponent({ props: { toast } })
+  const element = wrapper.get(`[role=${HTML_ROLE.ALERT}]`)
+  expect(element.attributes('aria-atomic')).toBe('true')
+  expect(element.attributes('aria-live')).toBe('assertive')
+  expect(element.classes()).toContain('is-error')
+})
+
+test('renders a button to dismiss the toast', async () => {
+  const removeSpy = spyOn.removeToast()
+  const wrapper = mountComponent({
+    props: {
+      toast: defaultToast,
+    },
+  })
+  const button = wrapper.get('button')
+  expect(button.text()).toBe(SHARED_COPY.ACTIONS.DISMISS)
+
+  await button.trigger('click')
+  expect(removeSpy).toHaveBeenCalledOnce()
+  expect(removeSpy).toHaveBeenCalledWith(defaultToast.id)
+})
+
+test(`automatically dismisses the toast after ${TOAST_HIDE_AFTER_MS}ms`, async () => {
+  vi.useFakeTimers()
+
+  const removeSpy = spyOn.removeToast()
+  mountComponent({
+    props: {
+      toast: defaultToast,
+    },
+  })
+
+  expect(removeSpy).not.toHaveBeenCalled()
+
+  await vi.advanceTimersByTimeAsync(TOAST_HIDE_AFTER_MS - 1)
+  expect(removeSpy).not.toHaveBeenCalled()
+
+  await vi.advanceTimersByTimeAsync(1)
+  expect(removeSpy).toHaveBeenCalledOnce()
+  expect(removeSpy).toHaveBeenCalledWith(defaultToast.id)
+
+  await vi.runOnlyPendingTimersAsync()
+  vi.useRealTimers()
+})
+
+test(`does not dismiss the toast on unmount`, async () => {
+  vi.useFakeTimers()
+
+  const removeSpy = spyOn.removeToast()
+  const wrapper = mountComponent({
+    props: {
+      toast: defaultToast,
+    },
+  })
+
+  expect(removeSpy).not.toHaveBeenCalled()
+
+  wrapper.unmount()
+  await vi.advanceTimersByTimeAsync(TOAST_HIDE_AFTER_MS)
+
+  expect(removeSpy).not.toHaveBeenCalled()
+
+  await vi.runOnlyPendingTimersAsync()
+  vi.useRealTimers()
+})

--- a/Okane.Client/src/shared/components/toast/Toast.vue
+++ b/Okane.Client/src/shared/components/toast/Toast.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+// External
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+
+// Internal
+import IconButton from '@shared/components/IconButton.vue'
+
+import { SHARED_COPY } from '@shared/constants/copy'
+import {
+  ERROR_TOAST_ATTRIBUTES,
+  SUCCESS_TOAST_ATTRIBUTES,
+  TOAST_HIDE_AFTER_MS,
+} from '@shared/constants/toast'
+
+import { type Toast as ToastType } from '@shared/types/toaster'
+
+import { useToastStore } from '@shared/composables/useToastStore'
+
+type Props = {
+  toast: ToastType
+}
+const props = defineProps<Props>()
+const timeout = ref<number>()
+
+const { removeToast } = useToastStore()
+const toastAttributes = computed(() => {
+  if (props.toast.type === 'error') {
+    return { ...ERROR_TOAST_ATTRIBUTES, class: 'is-error' }
+  }
+
+  return SUCCESS_TOAST_ATTRIBUTES
+})
+
+onMounted(() => {
+  timeout.value = setTimeout(() => {
+    removeToast(props.toast.id)
+  }, TOAST_HIDE_AFTER_MS)
+})
+
+onUnmounted(() => {
+  clearTimeout(timeout.value)
+})
+</script>
+
+<template>
+  <div class="toast" v-bind="toastAttributes">
+    <p>{{ props.toast.text }}</p>
+
+    <IconButton
+      class="dismiss-button"
+      :title="SHARED_COPY.ACTIONS.DISMISS"
+      icon="fa-solid fa-xmark"
+      @click="removeToast(props.toast.id)"
+    />
+  </div>
+</template>
+
+<style scoped>
+.dismiss-button {
+  right: 0;
+  top: 0;
+  position: absolute;
+}
+
+.toast {
+  background-color: var(--color-gray-700);
+  border-radius: 4px;
+  padding: var(--space-sm) var(--space-md);
+  position: relative;
+}
+
+.is-error {
+  background-color: var(--color-red-700);
+}
+</style>

--- a/Okane.Client/src/shared/components/toast/Toaster.spec.ts
+++ b/Okane.Client/src/shared/components/toast/Toaster.spec.ts
@@ -1,0 +1,35 @@
+// Internal
+import Toast from '@shared/components/toast/Toast.vue'
+import Toaster from '@shared/components/toast/Toaster.vue'
+
+import { useToastStore } from '@shared/composables/useToastStore'
+
+const mountComponent = getMountComponent(Toaster, {
+  global: {
+    stubs: {
+      IconButton: true,
+    },
+  },
+  withPinia: true,
+})
+
+test('renders a Toast for each toast', () => {
+  const parent = document.createElement('div')
+  parent.id = 'toaster'
+  document.body.appendChild(parent)
+
+  const toastStore = useToastStore()
+  const toastNames = new Set(['Toast 1', 'Toast 2', 'Toast 3'])
+  toastNames.forEach((name) => {
+    toastStore.createToast(name)
+  })
+
+  const wrapper = mountComponent()
+  const toasts = wrapper.findAllComponents(Toast)
+  toasts.forEach((toast) => {
+    expect(toastNames.has(toast.text())).toBe(true)
+    toastNames.delete(toast.text())
+  })
+
+  document.body.innerHTML = ''
+})

--- a/Okane.Client/src/shared/components/toast/Toaster.vue
+++ b/Okane.Client/src/shared/components/toast/Toaster.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+// Internal
+import Toast from '@shared/components/toast/Toast.vue'
+
+import { useToastStore } from '@shared/composables/useToastStore'
+
+const { toasts } = useToastStore()
+</script>
+
+<template>
+  <Teleport to="#toaster">
+    <TransitionGroup class="toaster" name="list" tag="div">
+      <Toast v-for="toast in toasts" :key="toast.id" :toast="toast" />
+    </TransitionGroup>
+  </Teleport>
+</template>
+
+<style scoped lang="scss">
+.toaster {
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 1.5rem;
+  margin-inline: auto;
+  position: fixed;
+  bottom: 25px;
+  left: 0;
+  right: 0;
+  width: 20rem;
+  z-index: var(--z-index-toaster);
+}
+
+.list-move,
+.list-enter-active,
+.list-leave-active {
+  transition: all 300ms ease;
+}
+
+.list-enter-from,
+.list-leave-to {
+  opacity: 0;
+  transform: translateY(30px);
+}
+</style>

--- a/Okane.Client/src/shared/composables/useToastStore.spec.ts
+++ b/Okane.Client/src/shared/composables/useToastStore.spec.ts
@@ -1,0 +1,34 @@
+// Internal
+import { useToastStore } from '@shared/composables/useToastStore'
+
+import { createTestToast } from '@tests/factories/toaster'
+
+test('creates and removes toasts', () => {
+  const { createToast, removeToast, toasts } = useToastStore()
+
+  const toast1 = createTestToast({ text: 'Cool toast' })
+  createToast(toast1.text)
+
+  const toast2 = createTestToast({ text: 'Bad toast', type: 'error' })
+  createToast(toast2.text, toast2.type)
+
+  expect(toasts).toEqual([
+    expect.objectContaining({
+      text: toast1.text,
+      type: toast1.type,
+    }),
+    expect.objectContaining({
+      text: toast2.text,
+      type: toast2.type,
+    }),
+  ])
+
+  removeToast(toasts[0].id)
+
+  expect(toasts).toEqual([
+    expect.objectContaining({
+      text: toast2.text,
+      type: toast2.type,
+    }),
+  ])
+})

--- a/Okane.Client/src/shared/composables/useToastStore.ts
+++ b/Okane.Client/src/shared/composables/useToastStore.ts
@@ -1,0 +1,34 @@
+// External
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+
+// Internal
+import { type Toast } from '@shared/types/toaster'
+
+export type ToastStore = ReturnType<typeof useToastStore>
+
+export const useToastStore = defineStore('ToastStore', () => {
+  const id = ref(0)
+  const toasts = ref<Toast[]>([])
+
+  function createToast(text: Toast['text'], type: Toast['type'] = 'success') {
+    toasts.value.push({ id: id.value, text, type })
+    id.value++
+  }
+
+  function removeToast(id: number) {
+    const indexToRemove = toasts.value.findIndex((toast) => toast.id === id)
+    if (indexToRemove !== -1) {
+      toasts.value.splice(indexToRemove, 1)
+    }
+  }
+
+  return {
+    get toasts() {
+      return toasts.value
+    },
+
+    createToast,
+    removeToast,
+  }
+})

--- a/Okane.Client/src/shared/constants/copy.ts
+++ b/Okane.Client/src/shared/constants/copy.ts
@@ -2,6 +2,7 @@ export const SHARED_COPY = {
   ACTIONS: {
     CANCEL: 'Cancel',
     DELETE: 'Delete',
+    DISMISS: 'Dismiss',
     EDIT: 'Edit',
     RENAME: 'Rename',
     RESET: 'Reset',

--- a/Okane.Client/src/shared/constants/html.ts
+++ b/Okane.Client/src/shared/constants/html.ts
@@ -1,4 +1,6 @@
 export const HTML_ROLE = {
+  ALERT: 'alert',
   COMBOBOX: 'combobox',
   SEPARATOR: 'separator',
+  STATUS: 'status',
 } as const

--- a/Okane.Client/src/shared/constants/testIds.ts
+++ b/Okane.Client/src/shared/constants/testIds.ts
@@ -1,0 +1,4 @@
+export const TEST_IDS = {
+  MODAL: 'modal',
+  MODAL_BACKDROP: 'modalBackdrop',
+} as const

--- a/Okane.Client/src/shared/constants/toast.ts
+++ b/Okane.Client/src/shared/constants/toast.ts
@@ -1,0 +1,16 @@
+// Internal
+import { HTML_ROLE } from '@shared/constants/html'
+
+export const TOAST_HIDE_AFTER_MS = 5000
+
+export const SUCCESS_TOAST_ATTRIBUTES = {
+  // "status' includes "aria-live" https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22.
+  role: HTML_ROLE.STATUS,
+  'aria-atomic': 'true',
+} as const
+
+export const ERROR_TOAST_ATTRIBUTES = {
+  role: HTML_ROLE.ALERT,
+  'aria-atomic': 'true',
+  'aria-live': 'assertive',
+} as const

--- a/Okane.Client/src/shared/pages/AccountPage.spec.ts
+++ b/Okane.Client/src/shared/pages/AccountPage.spec.ts
@@ -16,7 +16,15 @@ import { testServer } from '@tests/msw/testServer'
 function mountComponent() {
   testServer.use(authHandlers.getPasswordRequirementsSuccess())
 
-  return getMountComponent(AccountPage, { withQueryClient: true, withRouter: true })()
+  return getMountComponent(AccountPage, {
+    global: {
+      stubs: {
+        teleport: true,
+      },
+    },
+    withQueryClient: true,
+    withRouter: true,
+  })()
 }
 
 test('renders a heading', async () => {

--- a/Okane.Client/src/shared/pages/FinancesPage.spec.ts
+++ b/Okane.Client/src/shared/pages/FinancesPage.spec.ts
@@ -46,6 +46,7 @@ const mountComponent = getMountComponent(FinancesPage, {
       SearchFiltersSection: {
         template: `<div data-testid="${testIds.SearchFiltersSection}" />`,
       },
+      teleport: true,
       TotalRevenueAndExpenses: {
         template: `<div data-testid="${testIds.TotalRevenueAndExpenses}" />`,
       },

--- a/Okane.Client/src/shared/pages/ManageFinanceUserTagsPage.spec.ts
+++ b/Okane.Client/src/shared/pages/ManageFinanceUserTagsPage.spec.ts
@@ -40,6 +40,9 @@ function mountComponent(
       provide: {
         [MANAGE_FINANCE_USER_TAGS_PROVIDER_SYMBOL]: useManageFinanceUserTagsProvider(),
       },
+      stubs: {
+        teleport: true,
+      },
     },
     withQueryClient: true,
   })(args.mountingOptions)

--- a/Okane.Client/src/shared/styles/_base.scss
+++ b/Okane.Client/src/shared/styles/_base.scss
@@ -59,3 +59,14 @@ a {
   position: absolute;
   white-space: nowrap;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *, ::before, ::after {
+    animation-delay: -1s !important;
+    animation-duration: 1s !important;
+    animation-iteration-count: 1 !important;
+    background-attachment: initial !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0s !important;
+  }
+}

--- a/Okane.Client/src/shared/styles/index.scss
+++ b/Okane.Client/src/shared/styles/index.scss
@@ -1,6 +1,7 @@
 @import 'variables/colors';
 @import 'variables/spacing';
 @import 'variables/typography';
+@import 'variables/zIndex';
 @import 'themes/default';
 
 @import 'functions';

--- a/Okane.Client/src/shared/styles/variables/_zIndex.scss
+++ b/Okane.Client/src/shared/styles/variables/_zIndex.scss
@@ -1,0 +1,5 @@
+:root {
+  --z-index-modal: 2;
+  --z-index-toaster: 3;
+  --z-index-toggle-menu: 1;
+}

--- a/Okane.Client/src/shared/types/toaster.ts
+++ b/Okane.Client/src/shared/types/toaster.ts
@@ -1,0 +1,5 @@
+export type Toast = {
+  id: number
+  text: string
+  type: 'error' | 'success'
+}


### PR DESCRIPTION
## Description
- implement toasts that hide automatically after 5s
- show toast when create / edit finance record succeeds
- update modal to be a `div` rather than use a `dialog`. This was needed in order to render toasts on top of modals

![4401](https://github.com/user-attachments/assets/e4bd0e48-105d-4eb3-9ba8-47d64deb60b6)


## Linked issues
#41