### PR TITLE
Issue 117: Change `ToggleMenu` modal trigger to be the toggle icon

### DIFF
--- a/Okane.Client/src/shared/components/ToggleMenu.spec.ts
+++ b/Okane.Client/src/shared/components/ToggleMenu.spec.ts
@@ -7,6 +7,8 @@ import ToggleMenu from '@shared/components/ToggleMenu.vue'
 import { ARIA_ATTRIBUTES } from '@shared/constants/aria'
 import { SHARED_COPY } from '@shared/constants/copy'
 
+import { useModalTriggerStore } from '@shared/composables/useModalTriggerStore'
+
 const outsideOfMenuTestId = 'outsideOfMenu'
 
 const TestComponent = defineComponent({
@@ -85,16 +87,20 @@ describe('after clicking the menu toggle', () => {
     return { actions, wrapper }
   }
 
-  test('shows the menu', async () => {
+  test('shows the menu without setting the modal trigger', async () => {
+    const triggerStore = useModalTriggerStore()
     const { wrapper } = await setUp()
     const toggleButton = wrapper.get(selectors.toggleButton)
     expect(toggleButton.attributes(ARIA_ATTRIBUTES.EXPANDED)).toBe('true')
+    expect(triggerStore.modalTrigger).toBeNull()
 
     const menu = wrapper.get(selectors.menu)
     expect(menu.attributes('id')).toBe(props.menuId)
   })
 
   test('renders clickable menu actions', async () => {
+    const triggerStore = useModalTriggerStore()
+
     const { actions, wrapper } = await setUp()
     const menuLis = wrapper.findAll('li[role="presentation"]')
     expect(menuLis).toHaveLength(actions.length)
@@ -105,6 +111,15 @@ describe('after clicking the menu toggle', () => {
 
       await menuButton.trigger('click')
       expect(actions[i].onClick).toHaveBeenCalledOnce()
+
+      const toggleButton = wrapper.get(selectors.toggleButton)
+      expect(triggerStore.modalTrigger).toBe(toggleButton.element)
+
+      // After clicking an action, the menu should be closed and re-opened.
+      const menu = wrapper.find(selectors.menu)
+      expect(menu.exists()).toBe(false)
+
+      await toggleButton.trigger('click')
     }
   })
 })

--- a/Okane.Client/src/shared/components/ToggleMenu.vue
+++ b/Okane.Client/src/shared/components/ToggleMenu.vue
@@ -4,10 +4,12 @@ import { onClickOutside, onKeyStroke } from '@vueuse/core'
 import { ref, useTemplateRef } from 'vue'
 
 // Internal
+import AppButton from '@shared/components/button/AppButton.vue'
 import IconButton from '@shared/components/button/IconButton.vue'
-import ModalTrigger from '@shared/components/modal/ModalTrigger.vue'
 
 import { SHARED_COPY } from '@shared/constants/copy'
+
+import { useModalTriggerStore } from '@shared/composables/useModalTriggerStore'
 
 type MenuAction = {
   onClick: () => void
@@ -19,9 +21,11 @@ type Props = {
   menuId: string
 }
 
-const rootRef = useTemplateRef<HTMLDivElement>('rootRef')
+const rootRef = useTemplateRef('rootRef')
+const toggleRef = useTemplateRef('toggleRef')
 const props = defineProps<Props>()
 const menuIsShowing = ref(false)
+const triggerStore = useModalTriggerStore()
 
 onClickOutside(rootRef, () => {
   if (menuIsShowing.value) menuIsShowing.value = false
@@ -37,6 +41,8 @@ onKeyStroke(
 
 function handleClick(callback: MenuAction['onClick']) {
   callback()
+  menuIsShowing.value = false
+  triggerStore.setModalTrigger(toggleRef.value?.buttonRef ?? null)
 }
 </script>
 
@@ -46,8 +52,8 @@ function handleClick(callback: MenuAction['onClick']) {
       aria-haspopup="true"
       :aria-controls="props.menuId"
       :aria-expanded="menuIsShowing"
-      class="menu-toggle"
       icon="fa-solid fa-ellipsis-vertical"
+      ref="toggleRef"
       :title="SHARED_COPY.MENU.TOGGLE_MENU"
       @click="menuIsShowing = !menuIsShowing"
     />
@@ -59,9 +65,9 @@ function handleClick(callback: MenuAction['onClick']) {
         class="button-wrapper"
         role="presentation"
       >
-        <ModalTrigger class="menu-item" role="menuitem" @click="handleClick(action.onClick)">
+        <AppButton class="menu-item" role="menuitem" @click="handleClick(action.onClick)">
           {{ action.text }}
-        </ModalTrigger>
+        </AppButton>
       </li>
     </ul>
   </div>
@@ -77,13 +83,6 @@ function handleClick(callback: MenuAction['onClick']) {
   &:last-child {
     border-top: var(--border-main);
   }
-}
-
-.menu-toggle {
-  align-self: flex-end;
-  background: none;
-  display: grid;
-  place-items: center center;
 }
 
 .menu {


### PR DESCRIPTION
## Description
- when clicking a toggle menu option, set the modal trigger to the toggle menu trigger
- re-add closing the menu on option click


## Linked issues
#117