### PR TITLE
Issue 15: Rate limiting

### DIFF
--- a/Okane.Api.Tests/Features/Auth/Endpoints/SendVerificationEmailTests.cs
+++ b/Okane.Api.Tests/Features/Auth/Endpoints/SendVerificationEmailTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Net.Http.Json;
 using FluentAssertions;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,6 +6,10 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Okane.Api.Features.Auth.Endpoints;
 using Okane.Api.Infrastructure.Emails.Services;
 using Okane.Api.Infrastructure.Emails.Utils;
+using Okane.Api.Infrastructure.RateLimit;
+using Okane.Api.Shared.Constants;
+using Okane.Api.Tests.Testing.Assertions;
+using Okane.Api.Tests.Testing.Extensions;
 using Okane.Api.Tests.Testing.Integration;
 using Okane.Api.Tests.Testing.Mocks;
 
@@ -15,13 +18,22 @@ namespace Okane.Api.Tests.Features.Auth.Endpoints;
 public class SendVerificationEmailTests(PostgresApiFactory apiFactory) : DatabaseTest(apiFactory)
 {
     private readonly PostgresApiFactory _apiFactory = apiFactory;
+    private readonly string _endpointUrl = "/auth/send-verification-email";
+
+    private readonly IDictionary<string, string> _xUserEmailHeader = new Dictionary<string, string>
+    {
+        [HttpHeaderNames.XUserEmail] = TestUser.Email
+    };
 
     [Fact]
     public async Task ReturnsNoContent_WhenUserDoesNotExist()
     {
-        var request = new SendVerificationEmail.Request(TestUser.Email);
+        var request = new SendVerificationEmail.Request("random@okane.com");
         var client = _apiFactory.CreateClient();
-        var response = await client.PostAsJsonAsync("/auth/send-verification-email", request);
+        var response = await client.PostAsJsonAsync(_endpointUrl, request, new Dictionary<string, string>
+        {
+            [HttpHeaderNames.XUserEmail] = request.Email
+        });
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
@@ -44,7 +56,7 @@ public class SendVerificationEmailTests(PostgresApiFactory apiFactory) : Databas
         TestingEmailService.SetCalls(calls);
 
         var request = new SendVerificationEmail.Request(TestUser.Email);
-        var response = await client.PostAsJsonAsync("/auth/send-verification-email", request);
+        var response = await client.PostAsJsonAsync(_endpointUrl, request, _xUserEmailHeader);
         response.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
         calls.Should().HaveCount(1);

--- a/Okane.Api.Tests/Features/Auth/Utils/AuthUtilsTests.cs
+++ b/Okane.Api.Tests/Features/Auth/Utils/AuthUtilsTests.cs
@@ -1,0 +1,24 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Okane.Api.Features.Auth.Utils;
+using Okane.Api.Shared.Constants;
+
+namespace Okane.Api.Tests.Features.Auth.Utils;
+
+public class AuthUtilsTests
+{
+    public class ValidateXUserEmail
+    {
+        [Fact]
+        public void ReturnsTrue_WhenEmailsAreEqualCaseInsensitive()
+        {
+            var context = new DefaultHttpContext();
+            context.Request.Headers.Append(HttpHeaderNames.XUserEmail, "test@okane.com");
+
+            AuthUtils.ValidateXUserEmail(context, "test@okane.COM").Should().BeTrue();
+            AuthUtils.ValidateXUserEmail(context, "TEST@OKANE.COM").Should().BeTrue();
+
+            AuthUtils.ValidateXUserEmail(context, "other@okane.com").Should().BeFalse();
+        }
+    }
+}

--- a/Okane.Api.Tests/Shared/Extensions/HttpContextExtensionTests.cs
+++ b/Okane.Api.Tests/Shared/Extensions/HttpContextExtensionTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Okane.Api.Shared.Constants;
+using Okane.Api.Shared.Extensions;
+
+namespace Okane.Api.Tests.Shared.Extensions;
+
+public class HttpContextExtensionTests
+{
+    public class GetRemoteIpAddress
+    {
+        [Fact]
+        public void ReturnsTheIpAddress()
+        {
+            var context = new DefaultHttpContext();
+            context.GetRemoteIpAddress().Should().BeEmpty();
+
+            context.Connection.RemoteIpAddress = new IPAddress([127, 0, 0, 1]);
+            context.GetRemoteIpAddress().Should().Be("127.0.0.1");
+        }
+    }
+
+    public class GetXUserEmail
+    {
+        [Fact]
+        public void ReturnsTheHeaderValue_IfItExists()
+        {
+            var context = new DefaultHttpContext();
+            context.GetXUserEmail().Should().BeEmpty();
+
+            var email = "sir-doggo@okane.com";
+            context.Request.Headers.Append(HttpHeaderNames.XUserEmail, email);
+            context.GetXUserEmail().Should().Be(email);
+        }
+    }
+}

--- a/Okane.Api.Tests/Testing/Extensions/HttpClientExtensions.cs
+++ b/Okane.Api.Tests/Testing/Extensions/HttpClientExtensions.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Okane.Api.Tests.Testing.Extensions;
+
+public static class HttpClientExtensions
+{
+    // FROM: https://danieledwards.dev/postasjsonasync-now-with-headers#heading-option-2-extension-methods
+    public static Task<HttpResponseMessage> PostAsJsonAsync<TValue>(
+        this HttpClient client,
+        [StringSyntax(StringSyntaxAttribute.Uri)]
+        string? requestUri,
+        TValue value,
+        IDictionary<string, string> headers, // New parameter.
+        JsonSerializerOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var content = JsonContent.Create(value, null, options);
+        foreach (var header in headers)
+        {
+            // Just in case it was added elsewhere.
+            content.Headers.Remove(header.Key);
+            content.Headers.Add(header.Key, header.Value);
+        }
+
+        return client.PostAsync(requestUri, content, cancellationToken);
+    }
+}

--- a/Okane.Api.Tests/Testing/Integration/PostgresApiFactory.cs
+++ b/Okane.Api.Tests/Testing/Integration/PostgresApiFactory.cs
@@ -8,16 +8,12 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Okane.Api.Infrastructure.Database;
 using Okane.Api.Infrastructure.Emails.Services;
 using Okane.Api.Tests.Testing.Extensions;
 using Okane.Api.Tests.Testing.Mocks.Wrappers;
 using Respawn;
-using Serilog;
-using Serilog.AspNetCore;
-using Serilog.Events;
 using Testcontainers.PostgreSql;
 using ILoggerFactory = Microsoft.Extensions.Logging.ILoggerFactory;
 

--- a/Okane.Api.Tests/Testing/Integration/TestUser.cs
+++ b/Okane.Api.Tests/Testing/Integration/TestUser.cs
@@ -4,8 +4,10 @@ using Okane.Api.Features.Auth.Dtos.Responses;
 using Okane.Api.Features.Auth.Endpoints;
 using Okane.Api.Features.Auth.Entities;
 using Okane.Api.Infrastructure.Database;
+using Okane.Api.Shared.Constants;
 using Okane.Api.Shared.Dtos.ApiResponses;
 using Okane.Api.Tests.Features.Auth.Extensions;
+using Okane.Api.Tests.Testing.Extensions;
 
 namespace Okane.Api.Tests.Testing.Integration;
 
@@ -28,7 +30,10 @@ public static class TestUser
     public static async Task RegisterTestUserAsync(this HttpClient client)
     {
         var request = new Register.Request(User.Name, User.Email!, Password);
-        await client.PostAsJsonAsync("/auth/register", request);
+        await client.PostAsJsonAsync("/auth/register", request, new Dictionary<string, string>
+        {
+            { HttpHeaderNames.XUserEmail, request.Email }
+        });
     }
 
     /// <summary>

--- a/Okane.Api.Tests/Testing/Utils/UserUtils.cs
+++ b/Okane.Api.Tests/Testing/Utils/UserUtils.cs
@@ -1,8 +1,9 @@
-using System.Net.Http.Json;
 using Microsoft.EntityFrameworkCore;
 using Okane.Api.Features.Auth.Endpoints;
 using Okane.Api.Features.Auth.Entities;
 using Okane.Api.Infrastructure.Database;
+using Okane.Api.Shared.Constants;
+using Okane.Api.Tests.Testing.Extensions;
 using Okane.Api.Tests.Testing.Integration;
 using Okane.Api.Tests.Testing.StubFactories;
 
@@ -26,7 +27,10 @@ public static class UserUtils
 
     public static async Task RegisterUserAsync(HttpClient client, Register.Request request)
     {
-        await client.PostAsJsonAsync("/auth/register", request);
+        await client.PostAsJsonAsync("/auth/register", request, new Dictionary<string, string>
+        {
+            [HttpHeaderNames.XUserEmail] = request.Email
+        });
     }
 
     public static async Task<string> RegisterUserAsync(HttpClient client)

--- a/Okane.Api/Features/Auth/Endpoints/SendVerificationEmail.cs
+++ b/Okane.Api/Features/Auth/Endpoints/SendVerificationEmail.cs
@@ -4,10 +4,13 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Okane.Api.Features.Auth.Constants;
 using Okane.Api.Features.Auth.Entities;
+using Okane.Api.Features.Auth.Utils;
 using Okane.Api.Infrastructure.Database;
 using Okane.Api.Infrastructure.Emails.Services;
 using Okane.Api.Infrastructure.Emails.Utils;
 using Okane.Api.Infrastructure.Endpoints;
+using Okane.Api.Infrastructure.RateLimit;
+using Okane.Api.Shared.Exceptions;
 
 namespace Okane.Api.Features.Auth.Endpoints;
 
@@ -18,22 +21,30 @@ public class SendVerificationEmail : IEndpoint
         builder
             .MapPost("/send-verification-email", HandleAsync)
             .AllowAnonymous()
+            .RequireRateLimiting(RateLimitPolicyNames.EmailEndpoint)
             .WithName(AuthEndpointNames.SendVerificationEmail)
             .WithSummary("Send verification email to an unverified accounts.");
     }
 
     public record Request(string Email);
 
-    private static async Task<Results<BadRequest<ProblemDetails>, NoContent>>
+    private static async Task<Results<BadRequest<ProblemDetails>, InvalidXUserEmailResult, NoContent>>
         HandleAsync(
             HttpContext context,
             ApiDbContext db,
             IEmailService emailService,
-            ILogger<VerifyEmail> logger,
+            ILogger<SendVerificationEmail> logger,
             Request request,
             UserManager<ApiUser> userManager,
             CancellationToken cancellationToken)
     {
+        if (!AuthUtils.ValidateXUserEmail(context, request.Email))
+        {
+            logger.LogInformation("X-User-Email doesn't match request email: {Email}", request.Email);
+
+            return new InvalidXUserEmailResult();
+        }
+
         var user = await db.Users.SingleOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
         if (user is null)
         {

--- a/Okane.Api/Features/Auth/Utils/AuthUtils.cs
+++ b/Okane.Api/Features/Auth/Utils/AuthUtils.cs
@@ -1,0 +1,17 @@
+using Okane.Api.Shared.Extensions;
+
+namespace Okane.Api.Features.Auth.Utils;
+
+public static class AuthUtils
+{
+    /// <summary>
+    ///     Check that the X-User-Email header matches the email in the body.
+    /// </summary>
+    /// <param name="context"></param>
+    /// <param name="email"></param>
+    /// <returns></returns>
+    public static bool ValidateXUserEmail(HttpContext context, string email)
+    {
+        return context.GetXUserEmail().Equals(email, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Okane.Api/Features/Finances/Endpoints/PutRenameFinanceUserTag.cs
+++ b/Okane.Api/Features/Finances/Endpoints/PutRenameFinanceUserTag.cs
@@ -33,7 +33,7 @@ public class PutRenameFinanceUserTag : IEndpoint
             HttpContext context,
             ApiDbContext db,
             int financeUserTagId,
-            ILogger<PostFinanceUserTag> logger,
+            ILogger<PutRenameFinanceUserTag> logger,
             Request request,
             IFinanceTagService tagService,
             IValidator<FinanceRecord> validator,

--- a/Okane.Api/Infrastructure/Extensions/ConfigureApp.cs
+++ b/Okane.Api/Infrastructure/Extensions/ConfigureApp.cs
@@ -34,7 +34,11 @@ public static class ConfigureApp
         app.UseStatusCodePages();
         app.UseExceptionHandler();
 
-        app.UseHttpsRedirection();
+        var rateLimitingEnabled = app.Configuration.GetValue<bool>("RateLimitSettings:Enabled");
+        if (rateLimitingEnabled)
+        {
+            app.UseRateLimiter();
+        }
 
         app.UsePathBase("/api");
 

--- a/Okane.Api/Infrastructure/RateLimit/RateLimitAmounts.cs
+++ b/Okane.Api/Infrastructure/RateLimit/RateLimitAmounts.cs
@@ -1,0 +1,9 @@
+namespace Okane.Api.Infrastructure.RateLimit;
+
+public static class RateLimitAmounts
+{
+    public const int AuthenticatedUserLimit = 250;
+    public const int AnonymousUserLimit = 50;
+    public const int GlobalEmailLimit = 6;
+    public const int PerEndpointEmailLimit = 3;
+}

--- a/Okane.Api/Infrastructure/RateLimit/RateLimitPolicyNames.cs
+++ b/Okane.Api/Infrastructure/RateLimit/RateLimitPolicyNames.cs
@@ -1,0 +1,6 @@
+namespace Okane.Api.Infrastructure.RateLimit;
+
+public class RateLimitPolicyNames
+{
+    public const string EmailEndpoint = "EmailEndpoint";
+}

--- a/Okane.Api/Infrastructure/RateLimit/RateLimitSettings.cs
+++ b/Okane.Api/Infrastructure/RateLimit/RateLimitSettings.cs
@@ -1,0 +1,6 @@
+namespace Okane.Api.Infrastructure.RateLimit;
+
+public class RateLimitSettings
+{
+    public required bool Enabled { get; init; }
+}

--- a/Okane.Api/Shared/Constants/HttpHeaderNames.cs
+++ b/Okane.Api/Shared/Constants/HttpHeaderNames.cs
@@ -1,0 +1,6 @@
+namespace Okane.Api.Shared.Constants;
+
+public static class HttpHeaderNames
+{
+    public const string XUserEmail = "X-User-Email";
+}

--- a/Okane.Api/Shared/Exceptions/InvalidXUserEmailResult.cs
+++ b/Okane.Api/Shared/Exceptions/InvalidXUserEmailResult.cs
@@ -1,0 +1,33 @@
+using System.Net.Mime;
+using System.Reflection;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Okane.Api.Shared.Exceptions;
+
+public record InvalidXUserEmailResult : IResult, IEndpointMetadataProvider
+{
+    public const string ErrorDetail = "X-User-Email must match email in request body.";
+
+    public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
+    {
+        builder.Metadata.Add(
+            new ProducesResponseTypeMetadata(
+                StatusCodes.Status400BadRequest,
+                typeof(ProblemDetails),
+                [MediaTypeNames.Application.ProblemJson]
+            )
+        );
+    }
+
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        var response = TypedResults.Problem(new ProblemDetails
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Detail = ErrorDetail
+        });
+
+        await response.ExecuteAsync(httpContext);
+    }
+}

--- a/Okane.Api/Shared/Extensions/HttpContextExtensions.cs
+++ b/Okane.Api/Shared/Extensions/HttpContextExtensions.cs
@@ -1,0 +1,29 @@
+using Okane.Api.Shared.Constants;
+
+namespace Okane.Api.Shared.Extensions;
+
+public static class HttpContextExtensions
+{
+    /// <summary>
+    ///     Get HttpContext remote IP address.
+    /// </summary>
+    public static string GetRemoteIpAddress(this HttpContext context)
+    {
+        return context.Connection.RemoteIpAddress?.ToString() ?? "";
+    }
+
+    /// <summary>
+    ///     Get email stored in X-User-Email header.
+    /// </summary>
+    /// <param name="context"></param>
+    public static string GetXUserEmail(this HttpContext context)
+    {
+        var email = "";
+        if (context.Request.Headers.TryGetValue(HttpHeaderNames.XUserEmail, out var headerValue))
+        {
+            email = headerValue.FirstOrDefault() ?? "";
+        }
+
+        return email;
+    }
+}

--- a/Okane.Api/appsettings.Production.json
+++ b/Okane.Api/appsettings.Production.json
@@ -1,5 +1,8 @@
 {
     "AllowedHosts": "okane.philosocode.com",
+    "RateLimitSettings": {
+        "Enabled": true
+    },
     "Serilog": {
         "WriteTo": [
             {

--- a/Okane.Api/appsettings.json
+++ b/Okane.Api/appsettings.json
@@ -16,6 +16,9 @@
         "Audience": "https://okane.philosocode.com",
         "MinutesToExpiration": "1440"
     },
+    "RateLimitSettings": {
+        "Enabled": false
+    },
     "Serilog": {
         "MinimumLevel": {
             "Default": "Information",

--- a/Okane.Client/src/features/auth/composables/useAuthStore.spec.ts
+++ b/Okane.Client/src/features/auth/composables/useAuthStore.spec.ts
@@ -4,6 +4,7 @@ import { http, HttpResponse } from 'msw'
 // Internal
 import { authApiRoutes } from '@features/auth/constants/apiRoutes'
 import { HONEYPOT_INPUT_NAME } from '@shared/constants/form'
+import { HTTP_HEADER } from '@shared/constants/http'
 import { HTTP_STATUS_CODE } from '@shared/constants/http'
 
 import { type AuthenticateResponse } from '@features/auth/types/authResponse'
@@ -65,6 +66,11 @@ test('register', async () => {
   expect(spy).toHaveBeenCalledWith(
     authApiRoutes.register(),
     omitObjectKeys(formData, ['passwordConfirm']),
+    {
+      headers: {
+        [HTTP_HEADER.X_USER_EMAIL]: request.email,
+      },
+    },
   )
 })
 

--- a/Okane.Client/src/features/auth/composables/useAuthStore.ts
+++ b/Okane.Client/src/features/auth/composables/useAuthStore.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia'
 
 // Internal
 import { authApiRoutes } from '@features/auth/constants/apiRoutes'
+import { HTTP_HEADER } from '@shared/constants/http'
 
 import { type AuthenticateResponse } from '@features/auth/types/authResponse'
 import { type User } from '@features/users/types'
@@ -29,7 +30,11 @@ export const useAuthStore = defineStore('AuthStore', () => {
    * @param request
    */
   async function register(request: RegisterRequest): Promise<void> {
-    await apiClient.post(authApiRoutes.register(), request)
+    await apiClient.post(authApiRoutes.register(), request, {
+      headers: {
+        [HTTP_HEADER.X_USER_EMAIL]: request.email,
+      },
+    })
   }
 
   /**

--- a/Okane.Client/src/features/auth/composables/useSendResetPasswordEmail.spec.ts
+++ b/Okane.Client/src/features/auth/composables/useSendResetPasswordEmail.spec.ts
@@ -5,6 +5,7 @@ import { flushPromises } from '@vue/test-utils'
 // Internal
 import { authApiRoutes } from '@features/auth/constants/apiRoutes'
 import { HONEYPOT_INPUT_NAME } from '@shared/constants/form'
+import { HTTP_HEADER } from '@shared/constants/http'
 
 import { useSendResetPasswordEmail } from '@features/auth/composables/useSendResetPasswordEmail'
 
@@ -39,8 +40,16 @@ test('makes a POST request to the expected endpoint', async () => {
 
   mountComponent()
   await flushPromises()
-  expect(postSpy).toHaveBeenCalledWith(authApiRoutes.sendResetPasswordEmail(), {
-    email,
-    [HONEYPOT_INPUT_NAME]: honeypot,
-  })
+  expect(postSpy).toHaveBeenCalledWith(
+    authApiRoutes.sendResetPasswordEmail(),
+    {
+      email,
+      [HONEYPOT_INPUT_NAME]: honeypot,
+    },
+    {
+      headers: {
+        [HTTP_HEADER.X_USER_EMAIL]: email,
+      },
+    },
+  )
 })

--- a/Okane.Client/src/features/auth/composables/useSendResetPasswordEmail.ts
+++ b/Okane.Client/src/features/auth/composables/useSendResetPasswordEmail.ts
@@ -4,12 +4,17 @@ import { useMutation } from '@tanstack/vue-query'
 // Internal
 import { authApiRoutes } from '@features/auth/constants/apiRoutes'
 import { HONEYPOT_INPUT_NAME } from '@shared/constants/form'
+import { HTTP_HEADER } from '@shared/constants/http'
 
 import { apiClient } from '@shared/services/apiClient/apiClient'
 
 export function useSendResetPasswordEmail() {
   return useMutation({
     mutationFn: (body: { email: string; [HONEYPOT_INPUT_NAME]: string }) =>
-      apiClient.post(authApiRoutes.sendResetPasswordEmail(), body),
+      apiClient.post(authApiRoutes.sendResetPasswordEmail(), body, {
+        headers: {
+          [HTTP_HEADER.X_USER_EMAIL]: body.email,
+        },
+      }),
   })
 }

--- a/Okane.Client/src/features/auth/composables/useSendVerificationEmail.spec.ts
+++ b/Okane.Client/src/features/auth/composables/useSendVerificationEmail.spec.ts
@@ -4,6 +4,7 @@ import { flushPromises } from '@vue/test-utils'
 
 // Internal
 import { authApiRoutes } from '@features/auth/constants/apiRoutes'
+import { HTTP_HEADER } from '@shared/constants/http'
 
 import { useSendVerificationEmail } from '@features/auth/composables/useSendVerificationEmail'
 
@@ -34,5 +35,13 @@ test('makes a POST request to the expected endpoint', async () => {
 
   mountComponent()
   await flushPromises()
-  expect(postSpy).toHaveBeenCalledWith(authApiRoutes.sendVerificationEmail(), { email })
+  expect(postSpy).toHaveBeenCalledWith(
+    authApiRoutes.sendVerificationEmail(),
+    { email },
+    {
+      headers: {
+        [HTTP_HEADER.X_USER_EMAIL]: email,
+      },
+    },
+  )
 })

--- a/Okane.Client/src/features/auth/composables/useSendVerificationEmail.ts
+++ b/Okane.Client/src/features/auth/composables/useSendVerificationEmail.ts
@@ -3,11 +3,17 @@ import { useMutation } from '@tanstack/vue-query'
 
 // Internal
 import { apiClient } from '@shared/services/apiClient/apiClient'
+import { HTTP_HEADER } from '@shared/constants/http'
+
 import { authApiRoutes } from '@features/auth/constants/apiRoutes'
 
 export function useSendVerificationEmail() {
   return useMutation({
     mutationFn: (body: { email: string }) =>
-      apiClient.post(authApiRoutes.sendVerificationEmail(), body),
+      apiClient.post(authApiRoutes.sendVerificationEmail(), body, {
+        headers: {
+          [HTTP_HEADER.X_USER_EMAIL]: body.email,
+        },
+      }),
   })
 }

--- a/Okane.Client/src/shared/constants/http.ts
+++ b/Okane.Client/src/shared/constants/http.ts
@@ -1,3 +1,8 @@
+export enum HTTP_HEADER {
+  CONTENT_TYPE = 'Content-Type',
+  X_USER_EMAIL = 'X-User-Email',
+}
+
 export enum HTTP_METHOD {
   GET = 'GET',
   POST = 'POST',
@@ -15,6 +20,7 @@ export enum HTTP_STATUS_CODE {
   UNAUTHORIZED_401 = 401,
   FORBIDDEN_403 = 403,
   NOT_FOUND_404 = 404,
+  TOO_MANY_REQUESTS_429 = 429,
 }
 
 export enum MIME_TYPE {


### PR DESCRIPTION
## Description
### Limits
- 250 requests per minute per user for authenticated users
- 50 requests per minute per IP for unauthenticated users
- 6 requests per email per hour for email requests
- 3 requests per email per hour for the following endpoints:
    + `/api/auth/register`
    + `/api/auth/send-reset-password-email`
    + `/api/auth/send-verification-email`


## Linked issues
#15