### PR TITLE
164-BE: Fix Cursor pagination with decimal amount

### DIFF
--- a/Okane.Api.Tests/Features/Finances/Endpoints/GetPaginatedFinanceRecordsTests.cs
+++ b/Okane.Api.Tests/Features/Finances/Endpoints/GetPaginatedFinanceRecordsTests.cs
@@ -55,7 +55,7 @@ public class GetPaginatedFinanceRecordsTests(PostgresApiFactory apiFactory) : Da
         for (var i = 0; i < totalItems; i++)
         {
             var financeRecord = FinanceRecordStubFactory.Create(loginResponse.User.Id);
-            financeRecord.Amount = i + 1;
+            financeRecord.Amount = (decimal)(i + 1.11);
             financeRecords.Add(financeRecord);
         }
 

--- a/Okane.Api/Features/Finances/Dtos/FinanceRecordCursorQueryParameters.cs
+++ b/Okane.Api/Features/Finances/Dtos/FinanceRecordCursorQueryParameters.cs
@@ -5,6 +5,6 @@ public class FinanceRecordCursorQueryParameters
     public int? CursorId { get; set; }
 
     // One of CursorAmount and CursorHappenedAt should be passed, but not both.
-    public int? CursorAmount { get; set; }
+    public decimal? CursorAmount { get; set; }
     public DateTime? CursorHappenedAt { get; set; }
 }


### PR DESCRIPTION
## Description
Was getting a parameter binding error because decimal amounts were trying to get bound to an int param.


## Linked issues
#164