### PR TITLE
166-FE: Fix space below `<fieldset>` elements on Safari

### DIFF
--- a/Okane.Client/src/features/financeRecords/components/searchFilters/SearchFiltersForm.vue
+++ b/Okane.Client/src/features/financeRecords/components/searchFilters/SearchFiltersForm.vue
@@ -154,8 +154,7 @@ function handleSubmit() {
 
 <style scoped>
 .form {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: var(--space-lg);
 }
 


### PR DESCRIPTION
## Description
This happens when you have a `<fieldset>` with a `<legend>` inside a form with `display: flex`.

See: https://bugs.webkit.org/show_bug.cgi?id=245402

https://github.com/user-attachments/assets/11a0676c-dc9b-4035-a126-8c85ccd242df


## Linked issues
#166