### PR TITLE
Issue 168: Fix inconsistent date input height & text vertical align in Safari

### DIFF
--- a/Okane.Client/src/shared/components/form/FormInput.vue
+++ b/Okane.Client/src/shared/components/form/FormInput.vue
@@ -73,7 +73,8 @@ function handleChange(event: Event) {
   border: var(--border-main);
   border-radius: var(--border-radius);
   color: var(--color-text);
-  display: block;
+  display: flex;
+  align-items: center;
   width: 100%;
 }
 </style>

--- a/Okane.Client/src/shared/styles/components/_form.scss
+++ b/Okane.Client/src/shared/styles/components/_form.scss
@@ -1,4 +1,4 @@
 .form-input {
-  min-height: 2.3rem;
+  height: 2.3rem;
   padding-inline: var(--space-xs);
 }


### PR DESCRIPTION
## Before
<img width="194" height="127" alt="image" src="https://github.com/user-attachments/assets/9cc70567-921c-407e-9f1b-a5404b7c8ace" />

## After
<img width="194" height="128" alt="image" src="https://github.com/user-attachments/assets/264102e4-db03-4581-a10c-097de42cdb3a" />

## Linked issues
#168